### PR TITLE
Add e2e tests for user registration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 export default {
   roots: ['<rootDir>/src'],
+  setupFilesAfterEnv: ['<rootDir>/src/tests/e2e/setupTests.ts'],
   testMatch: [
     '**/__tests__/**/*.+(ts|tsx|js)',
     '**/?(*.)+(spec|test).+(ts|tsx|js)',

--- a/src/NFTBarter_assets/src/utils/createActor.ts
+++ b/src/NFTBarter_assets/src/utils/createActor.ts
@@ -1,0 +1,44 @@
+import {
+  Actor,
+  HttpAgent,
+  HttpAgentOptions,
+  ActorConfig,
+} from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
+import { IDL } from '@dfinity/candid';
+
+export function curriedCreateActor<T>(idlFactory: IDL.InterfaceFactory) {
+  return (canisterId: string | Principal) => {
+    return (options: {
+      agentOptions?: HttpAgentOptions;
+      actorOptions?: ActorConfig;
+    }) => {
+      const agent = new HttpAgent({ ...options?.agentOptions });
+
+      // Fetch root key for certificate validation during development
+      if (process.env.NODE_ENV !== 'production') {
+        agent.fetchRootKey().catch((err) => {
+          console.warn(
+            'Unable to fetch root key. Check to ensure that your local replica is running'
+          );
+          console.error(err);
+        });
+      }
+
+      // Creates an actor with using the candid interface and the HttpAgent
+      return Actor.createActor<T>(idlFactory, {
+        agent,
+        canisterId,
+        ...options?.actorOptions,
+      });
+    };
+  };
+}
+
+export function createActor<T>(
+  idlFactory: IDL.InterfaceFactory,
+  canisterId: string | Principal,
+  options: { agentOptions?: HttpAgentOptions; actorOptions?: ActorConfig }
+) {
+  return curriedCreateActor<T>(idlFactory)(canisterId)(options);
+}

--- a/src/declarations/NFTBarter/NFTBarter.old.did
+++ b/src/declarations/NFTBarter/NFTBarter.old.did
@@ -1,19 +1,14 @@
-type UserId__1 = principal;
+type UserProfile = variant {none;};
 type UserId = principal;
 type Result_1 = 
  variant {
    err: text;
-   ok: DefiniteUser;
+   ok: UserProfile;
  };
 type Result = 
  variant {
    err: text;
    ok: UserId;
- };
-type DefiniteUser = 
- record {
-   id: UserId__1;
-   name: text;
  };
 service : {
   getMyInfo: () -> (Result_1) query;

--- a/src/tests/e2e/registration.test.ts
+++ b/src/tests/e2e/registration.test.ts
@@ -1,0 +1,46 @@
+import { Secp256k1KeyIdentity } from '@dfinity/identity';
+import fetch from 'isomorphic-fetch';
+import { IDL } from '@dfinity/candid';
+
+declare module '../../declarations/NFTBarter/NFTBarter.did.js' {
+  function idlFactory(): IDL.ServiceClass;
+}
+import {
+  _SERVICE as INFTBarter,
+  idlFactory,
+} from '../../declarations/NFTBarter/NFTBarter.did.js';
+import { curriedCreateActor } from '../../NFTBarter_assets/src/utils/createActor';
+import localCanisterIds from '../../../.dfx/local/canister_ids.json';
+
+const canisterId = localCanisterIds.NFTBarter.local;
+
+const createNFTBarterActor =
+  curriedCreateActor<INFTBarter>(idlFactory)(canisterId);
+
+const identityOptionOfAlice = {
+  agentOptions: {
+    identity: Secp256k1KeyIdentity.generate(),
+    fetch,
+    host: 'http://localhost:8000',
+  },
+};
+const actorOfAlice = createNFTBarterActor(identityOptionOfAlice);
+
+describe('User registration tests', () => {
+  it('Alice is not registered yet.', async () => {
+    expect(await actorOfAlice.isRegistered()).toBe(false);
+  });
+
+  it('Alice can be registered.', async () => {
+    const res = await actorOfAlice.register();
+    if ('ok' in res) {
+      expect(res.ok._isPrincipal).toBe(true);
+    } else {
+      throw new Error(res.err);
+    }
+  });
+
+  it('Alice is already registered.', async () => {
+    expect(await actorOfAlice.isRegistered()).toBe(true);
+  });
+});

--- a/src/tests/e2e/sample.test.ts
+++ b/src/tests/e2e/sample.test.ts
@@ -1,5 +1,0 @@
-describe('Sample test', () => {
-  it('should check that test passes.', async () => {
-    expect(true).toBe(true);
-  });
-});

--- a/src/tests/e2e/setupTests.ts
+++ b/src/tests/e2e/setupTests.ts
@@ -1,0 +1,4 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;


### PR DESCRIPTION
# 概要・目的
ユーザー登録機能に対する E2E テストの追加
<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
Refers #14

# 変更内容
## やったこと
- Canister テストのためのコード整備
- ユーザー登録機能に対する E2E テストコードの追加
<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
- フロントエンドコードに対する修正（#14 の残りタスク）
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
NATBarter_assets 内のテストコード
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
```
./scripts/install_local.sh
```
で Canister デプロイ後に
```
npm run test
```
を実行。
結果は以下の通り：
```
 PASS  src/tests/e2e/registration.test.ts (6.486 s)
  User registration tests
    ✓ Alice is not registered yet. (39 ms)
    ✓ Alice can be registered. (2153 ms)
    ✓ Alice is already registered. (8 ms)
```

<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足

<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
