### PR TITLE
Add frontend codes for handling user registrations

### DIFF
--- a/src/NFTBarter/main.mo
+++ b/src/NFTBarter/main.mo
@@ -34,7 +34,7 @@ shared (install) actor class NFTBarter() = this {
   // Traps if:
   //   - `caller` is not a registered user.
   //   - `caller` is the anonymous identity.
-  public shared ({ caller }) func register(): async Result<UserId,Text>{
+  public shared ({ caller }) func register(): async Result<UserProfile,Text>{
     if (Principal.isAnonymous(caller)) { return #err "You need to be authenticated." };
     switch (_userProfiles.get(caller)) {
       case (?_) {
@@ -43,7 +43,7 @@ shared (install) actor class NFTBarter() = this {
       case null {
         let userProfile : UserProfile = #none;
         _userProfiles.put(caller, userProfile);
-        #ok caller
+        #ok userProfile
       };
     }
   };

--- a/src/NFTBarter_assets/src/app/store.ts
+++ b/src/NFTBarter_assets/src/app/store.ts
@@ -1,4 +1,9 @@
-import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
+import {
+  configureStore,
+  ThunkAction,
+  Action,
+  Dispatch,
+} from '@reduxjs/toolkit';
 import authReducer from '../features/auth/authSlice';
 
 export const store = configureStore({
@@ -15,3 +20,8 @@ export type AppThunk<ReturnType = void> = ThunkAction<
   unknown,
   Action<string>
 >;
+export type AsyncThunkConfig<T = unknown> = {
+  state: RootState;
+  dispatch: Dispatch;
+  rejectValue: T;
+};

--- a/src/NFTBarter_assets/src/features/auth/SampleLoginPage.tsx
+++ b/src/NFTBarter_assets/src/features/auth/SampleLoginPage.tsx
@@ -8,6 +8,8 @@ import {
   logout,
   selectIsLogin,
   selectPrincipal,
+  selectUserProfile,
+  selectErrorMessage,
 } from './authSlice';
 
 interface ButtonProps {
@@ -34,6 +36,8 @@ export const SampleLoginPage: FC = () => {
   const dispatch = useAppDispatch();
   const isLogin = useAppSelector(selectIsLogin);
   const principal = useAppSelector(selectPrincipal);
+  const userProfile = useAppSelector(selectUserProfile);
+  const errorMessage = useAppSelector(selectErrorMessage);
 
   const handleLoginClick = async () => {
     await dispatch(login());
@@ -51,7 +55,12 @@ export const SampleLoginPage: FC = () => {
     <Center h='200px'>
       <VStack>
         <h1>Sample Login Page</h1>
+        {userProfile && (
+          <Text>USER PROFILE : {JSON.stringify(userProfile)}</Text>
+        )}
         {principal && <Text>YOUR PRINCIPAL IS : {principal}</Text>}
+        {errorMessage && <Text>ERROR : {errorMessage}</Text>}
+
         {isLogin ? (
           <SampleButton onClick={handleLogoutClick} text={'Logout'} />
         ) : (

--- a/src/NFTBarter_assets/src/utils/createNFTBarterActor.ts
+++ b/src/NFTBarter_assets/src/utils/createNFTBarterActor.ts
@@ -1,0 +1,16 @@
+import { IDL } from '@dfinity/candid';
+
+declare module '../../../declarations/NFTBarter/NFTBarter.did.js' {
+  function idlFactory(): IDL.ServiceClass;
+}
+import {
+  _SERVICE as INFTBarter,
+  idlFactory,
+} from '../../../declarations/NFTBarter/NFTBarter.did.js';
+import { curriedCreateActor } from '../../../NFTBarter_assets/src/utils/createActor';
+import localCanisterIds from '../../../../.dfx/local/canister_ids.json';
+
+const canisterId = localCanisterIds.NFTBarter.local;
+
+export const createNFTBarterActor =
+  curriedCreateActor<INFTBarter>(idlFactory)(canisterId);

--- a/src/declarations/NFTBarter/NFTBarter.did
+++ b/src/declarations/NFTBarter/NFTBarter.did
@@ -1,18 +1,12 @@
 type UserProfile = variant {none;};
-type UserId = principal;
-type Result_1 = 
+type Result = 
  variant {
    err: text;
    ok: UserProfile;
  };
-type Result = 
- variant {
-   err: text;
-   ok: UserId;
- };
 type NFTBarter = 
  service {
-   getMyProfile: () -> (Result_1) query;
+   getMyProfile: () -> (Result) query;
    isRegistered: () -> (bool) query;
    register: () -> (Result);
  };

--- a/src/declarations/NFTBarter/NFTBarter.did.d.ts
+++ b/src/declarations/NFTBarter/NFTBarter.did.d.ts
@@ -1,13 +1,10 @@
 import type { Principal } from '@dfinity/principal';
 export interface NFTBarter {
-  'getMyProfile' : () => Promise<Result_1>,
+  'getMyProfile' : () => Promise<Result>,
   'isRegistered' : () => Promise<boolean>,
   'register' : () => Promise<Result>,
 }
-export type Result = { 'ok' : UserId } |
+export type Result = { 'ok' : UserProfile } |
   { 'err' : string };
-export type Result_1 = { 'ok' : UserProfile } |
-  { 'err' : string };
-export type UserId = Principal;
 export type UserProfile = { 'none' : null };
 export interface _SERVICE extends NFTBarter {}

--- a/src/declarations/NFTBarter/NFTBarter.did.js
+++ b/src/declarations/NFTBarter/NFTBarter.did.js
@@ -1,10 +1,8 @@
 export const idlFactory = ({ IDL }) => {
   const UserProfile = IDL.Variant({ 'none' : IDL.Null });
-  const Result_1 = IDL.Variant({ 'ok' : UserProfile, 'err' : IDL.Text });
-  const UserId = IDL.Principal;
-  const Result = IDL.Variant({ 'ok' : UserId, 'err' : IDL.Text });
+  const Result = IDL.Variant({ 'ok' : UserProfile, 'err' : IDL.Text });
   const NFTBarter = IDL.Service({
-    'getMyProfile' : IDL.Func([], [Result_1], ['query']),
+    'getMyProfile' : IDL.Func([], [Result], ['query']),
     'isRegistered' : IDL.Func([], [IDL.Bool], ['query']),
     'register' : IDL.Func([], [Result], []),
   });

--- a/src/declarations/NFTBarter/NFTBarter.old.did
+++ b/src/declarations/NFTBarter/NFTBarter.old.did
@@ -1,17 +1,11 @@
 type UserProfile = variant {none;};
-type UserId = principal;
-type Result_1 = 
+type Result = 
  variant {
    err: text;
    ok: UserProfile;
  };
-type Result = 
- variant {
-   err: text;
-   ok: UserId;
- };
 service : {
-  getMyInfo: () -> (Result_1) query;
+  getMyProfile: () -> (Result) query;
   isRegistered: () -> (bool) query;
   register: () -> (Result);
 }

--- a/src/tests/e2e/registration.test.ts
+++ b/src/tests/e2e/registration.test.ts
@@ -6,6 +6,7 @@ declare module '../../declarations/NFTBarter/NFTBarter.did.js' {
   function idlFactory(): IDL.ServiceClass;
 }
 import {
+  UserProfile,
   _SERVICE as INFTBarter,
   idlFactory,
 } from '../../declarations/NFTBarter/NFTBarter.did.js';
@@ -14,6 +15,8 @@ import localCanisterIds from '../../../.dfx/local/canister_ids.json';
 
 const canisterId = localCanisterIds.NFTBarter.local;
 
+// We don't import `createNFTBarterActor` from `createNFTBarterActor.ts`
+// because it gives an error in jest running on GitHub Actions.
 const createNFTBarterActor =
   curriedCreateActor<INFTBarter>(idlFactory)(canisterId);
 
@@ -26,6 +29,8 @@ const identityOptionOfAlice = {
 };
 const actorOfAlice = createNFTBarterActor(identityOptionOfAlice);
 
+const initialUserProfile: UserProfile = { none: null };
+
 describe('User registration tests', () => {
   it('Alice is not registered yet.', async () => {
     expect(await actorOfAlice.isRegistered()).toBe(false);
@@ -34,7 +39,7 @@ describe('User registration tests', () => {
   it('Alice can be registered.', async () => {
     const res = await actorOfAlice.register();
     if ('ok' in res) {
-      expect(res.ok._isPrincipal).toBe(true);
+      expect(res.ok).toStrictEqual(initialUserProfile);
     } else {
       throw new Error(res.err);
     }


### PR DESCRIPTION
# 概要・目的
ユーザー登録のフロントエンドコードを追加する
<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
Fixes #14 

# 変更内容
## やったこと
- `authSlice` に actor の `register()` と `getMyProfile()` をコールするロジックを追加
- `createAsyncThunk` で `rejectWithValue` を使ったエラーハンドリングを追加
- `promisedLogin` の返し値を `Promise<{ res: Result; principal: string }>` にするために `register()` の返し値を `UserProfile` に変更
<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
`UserProfile` に Principal ID を追加する
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
### NFTBarter
- `register()` の返し値
### NFTBarter_assets:
- `authSlice` と関連する型関係のコード
- SampleLoginPage の表示
- e2e テスト
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
## フロントエンド
```
./script/install_local.sh
npm run start
```
でログインすると USER PROFILE が表示される。
![image](https://user-images.githubusercontent.com/40290137/168069938-8eb918d7-3a13-4705-aeaf-8860ecbfc3cf.png)

## e2eテスト
```
npm run test
```
結果は以下の通り：
```

> NFTBarter_assets@0.1.0 test
> NODE_OPTIONS=--experimental-vm-modules jest

(node:73351) ExperimentalWarning: VM Modules is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 PASS  src/tests/e2e/registration.test.ts (8.722 s)
  User registration tests
    ✓ Alice is not registered yet. (43 ms)
    ✓ Alice can be registered. (2192 ms)
    ✓ Alice is already registered. (8 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        9.389 s
Ran all test suites.
```

<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足
TypeScriptの異常系の表現はなかなか難しい問題[[参照]](https://dev.classmethod.jp/articles/error-handling-practice-of-typescript/)ですが、MotokoからResult型を返す場合の（今の所の）ベストプラクティスと考えているのが、Result型をできるだけそのまま活用する方法です。
今回の場合、以下のように`createAsyncThunk` で`res.err`を`rejectWithValue`に渡しています。

```TypeScript
    if ('ok' in res) {
      return {
        isLogin: true,
        principal: identity.getPrincipal().toText(),
        userProfile: res.ok,
      };
    } else {
      return rejectWithValue({ errorMessage: res.err });
    }
```
<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
