### PR TITLE
Add Error variant type for better error handling

### DIFF
--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -7,4 +7,11 @@ module {
     #none;
   };
 
+  public type Error = {
+    #unauthorized : Text;
+    #notYetRegistered : Text;
+    #alreadyRegistered : Text;
+    #other : Text;
+  }
+
 }

--- a/src/NFTBarter/main.mo
+++ b/src/NFTBarter/main.mo
@@ -14,6 +14,7 @@ shared (install) actor class NFTBarter() = this {
   type UserProfile = Types.UserProfile;
   type UserId = Types.UserId;
   type CanisterID = Types.CanisterID;
+  type Error = Types.Error;
   type Result<T, E> = Result.Result<T, E>;
 
   let installer : Principal = install.caller;
@@ -34,11 +35,11 @@ shared (install) actor class NFTBarter() = this {
   // Traps if:
   //   - `caller` is not a registered user.
   //   - `caller` is the anonymous identity.
-  public shared ({ caller }) func register(): async Result<UserProfile,Text>{
-    if (Principal.isAnonymous(caller)) { return #err "You need to be authenticated." };
+  public shared ({ caller }) func register(): async Result<UserProfile,Error>{
+    if (Principal.isAnonymous(caller)) { return #err(#unauthorized(Principal.toText(caller))) };
     switch (_userProfiles.get(caller)) {
       case (?_) {
-        #err "This principal id is already in use."
+        #err(#alreadyRegistered "This principal id is already in use.")
       };
       case null {
         let userProfile : UserProfile = #none;
@@ -50,10 +51,10 @@ shared (install) actor class NFTBarter() = this {
 
   // Returns `userProfile` associated with `caller`
   // Traps if `caller` is not a registered user.
-  public query ({ caller }) func getMyProfile(): async Result<UserProfile,Text> {
+  public query ({ caller }) func getMyProfile(): async Result<UserProfile,Error> {
     switch (_userProfiles.get(caller)) {
       case (?userProfile) { #ok userProfile };
-      case null { #err "You are not registered." };
+      case null { #err(#notYetRegistered "You are not registered.")};
     }
   };
 

--- a/src/NFTBarter_assets/src/features/auth/SampleLoginPage.tsx
+++ b/src/NFTBarter_assets/src/features/auth/SampleLoginPage.tsx
@@ -9,7 +9,7 @@ import {
   selectIsLogin,
   selectPrincipal,
   selectUserProfile,
-  selectErrorMessage,
+  selectError,
 } from './authSlice';
 
 interface ButtonProps {
@@ -37,7 +37,7 @@ export const SampleLoginPage: FC = () => {
   const isLogin = useAppSelector(selectIsLogin);
   const principal = useAppSelector(selectPrincipal);
   const userProfile = useAppSelector(selectUserProfile);
-  const errorMessage = useAppSelector(selectErrorMessage);
+  const error = useAppSelector(selectError);
 
   const handleLoginClick = async () => {
     await dispatch(login());
@@ -59,7 +59,7 @@ export const SampleLoginPage: FC = () => {
           <Text>USER PROFILE : {JSON.stringify(userProfile)}</Text>
         )}
         {principal && <Text>YOUR PRINCIPAL IS : {principal}</Text>}
-        {errorMessage && <Text>ERROR : {errorMessage}</Text>}
+        {error && <Text>ERROR : {JSON.stringify(error)}</Text>}
 
         {isLogin ? (
           <SampleButton onClick={handleLogoutClick} text={'Logout'} />

--- a/src/NFTBarter_assets/src/features/auth/authSlice.ts
+++ b/src/NFTBarter_assets/src/features/auth/authSlice.ts
@@ -7,6 +7,7 @@ import { createNFTBarterActor } from '../../utils/createNFTBarterActor';
 import {
   UserProfile,
   Result,
+  Error,
 } from '../../../../declarations/NFTBarter/NFTBarter.did';
 
 const DAYS = BigInt(1);
@@ -17,7 +18,7 @@ export interface AuthState {
   isLogin: boolean;
   principal?: string;
   userProfile?: UserProfile;
-  errorMessage?: string;
+  error?: Error;
 }
 
 const initialState: AuthState = {
@@ -72,7 +73,7 @@ const promisedLogin = (authClient: AuthClient) =>
 export const checkAuth = createAsyncThunk<
   AuthState,
   undefined,
-  AsyncThunkConfig<{ errorMessage: string }>
+  AsyncThunkConfig<{ error: Error }>
 >('auth/isAuth', async (_, { rejectWithValue }) => {
   const authClient = await AuthClient.create();
   if (await authClient.isAuthenticated()) {
@@ -85,7 +86,7 @@ export const checkAuth = createAsyncThunk<
         userProfile: res.ok,
       };
     } else {
-      return rejectWithValue({ errorMessage: res.err });
+      return rejectWithValue({ error: res.err });
     }
   } else {
     return { isLogin: false };
@@ -95,7 +96,7 @@ export const checkAuth = createAsyncThunk<
 export const login = createAsyncThunk<
   AuthState,
   undefined,
-  AsyncThunkConfig<{ errorMessage: string }>
+  AsyncThunkConfig<{ error: Error }>
 >('auth/login', async (_, { rejectWithValue }) => {
   const authClient = await AuthClient.create();
 
@@ -109,7 +110,7 @@ export const login = createAsyncThunk<
       principal,
     };
   } else {
-    return rejectWithValue({ errorMessage: res.err });
+    return rejectWithValue({ error: res.err });
   }
 });
 
@@ -131,7 +132,7 @@ export const authSlice = createSlice({
       state.userProfile = action.payload.userProfile;
     });
     builder.addCase(login.rejected, (state, action) => {
-      state.errorMessage = action.payload?.errorMessage;
+      state.error = action.payload?.error;
     });
     builder.addCase(checkAuth.fulfilled, (state, action) => {
       state.isLogin = action.payload.isLogin;
@@ -139,7 +140,7 @@ export const authSlice = createSlice({
       state.userProfile = action.payload.userProfile;
     });
     builder.addCase(checkAuth.rejected, (state, action) => {
-      state.errorMessage = action.payload?.errorMessage;
+      state.error = action.payload?.error;
     });
   },
 });
@@ -149,6 +150,6 @@ export const { logout } = authSlice.actions;
 export const selectIsLogin = (state: RootState) => state.auth.isLogin;
 export const selectPrincipal = (state: RootState) => state.auth.principal;
 export const selectUserProfile = (state: RootState) => state.auth.userProfile;
-export const selectErrorMessage = (state: RootState) => state.auth.errorMessage;
+export const selectError = (state: RootState) => state.auth.error;
 
 export default authSlice.reducer;

--- a/src/declarations/NFTBarter/NFTBarter.did
+++ b/src/declarations/NFTBarter/NFTBarter.did
@@ -1,7 +1,7 @@
 type UserProfile = variant {none;};
 type Result = 
  variant {
-   err: text;
+   err: Error;
    ok: UserProfile;
  };
 type NFTBarter = 
@@ -10,5 +10,12 @@ type NFTBarter =
    isRegistered: () -> (bool) query;
    mintChildCanister: () -> (principal);
    register: () -> (Result);
+ };
+type Error = 
+ variant {
+   alreadyRegistered: text;
+   notYetRegistered: text;
+   other: text;
+   unauthorized: text;
  };
 service : () -> NFTBarter

--- a/src/declarations/NFTBarter/NFTBarter.did.d.ts
+++ b/src/declarations/NFTBarter/NFTBarter.did.d.ts
@@ -1,4 +1,8 @@
 import type { Principal } from '@dfinity/principal';
+export type Error = { 'other' : string } |
+  { 'alreadyRegistered' : string } |
+  { 'unauthorized' : string } |
+  { 'notYetRegistered' : string };
 export interface NFTBarter {
   'getMyProfile' : () => Promise<Result>,
   'isRegistered' : () => Promise<boolean>,
@@ -6,6 +10,6 @@ export interface NFTBarter {
   'register' : () => Promise<Result>,
 }
 export type Result = { 'ok' : UserProfile } |
-  { 'err' : string };
+  { 'err' : Error };
 export type UserProfile = { 'none' : null };
 export interface _SERVICE extends NFTBarter {}

--- a/src/declarations/NFTBarter/NFTBarter.did.js
+++ b/src/declarations/NFTBarter/NFTBarter.did.js
@@ -1,6 +1,12 @@
 export const idlFactory = ({ IDL }) => {
   const UserProfile = IDL.Variant({ 'none' : IDL.Null });
-  const Result = IDL.Variant({ 'ok' : UserProfile, 'err' : IDL.Text });
+  const Error = IDL.Variant({
+    'other' : IDL.Text,
+    'alreadyRegistered' : IDL.Text,
+    'unauthorized' : IDL.Text,
+    'notYetRegistered' : IDL.Text,
+  });
+  const Result = IDL.Variant({ 'ok' : UserProfile, 'err' : Error });
   const NFTBarter = IDL.Service({
     'getMyProfile' : IDL.Func([], [Result], ['query']),
     'isRegistered' : IDL.Func([], [IDL.Bool], ['query']),

--- a/src/tests/e2e/registration.test.ts
+++ b/src/tests/e2e/registration.test.ts
@@ -46,9 +46,11 @@ describe('User registration tests', () => {
 
   it('Alice has no profile yet.', async () => {
     const res = await actorOfAlice.getMyProfile();
-    if (!('err' in res)) {
-      throw new Error('getMyProfile should return err berofe registration.');
-    }
+    expect(res).toEqual({
+      err: {
+        notYetRegistered: expect.anything(),
+      },
+    });
   });
 
   it('Alice can be registered.', async () => {
@@ -73,15 +75,19 @@ describe('User registration tests', () => {
 describe('Anonymous registration tests', () => {
   it('Anomymous identity can not register.', async () => {
     const res = await actorOfAnonymous.register();
-    expect(res).toStrictEqual({
-      err: 'You need to be authenticated.',
+    expect(res).toEqual({
+      err: {
+        unauthorized: expect.anything(),
+      },
     });
   });
 
   it('Anonymous identity never has its own profile.', async () => {
     const res = await actorOfAnonymous.getMyProfile();
-    expect(res).toStrictEqual({
-      err: 'You are not registered.',
+    expect(res).toEqual({
+      err: {
+        notYetRegistered: expect.anything(),
+      },
     });
   });
 


### PR DESCRIPTION
# 概要・目的
Result の err を Text ではなく Variantで返すように修正
<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
Fixes #50 

# 変更内容
## やったこと
- Error variantを定義
- canister public funcのResultをerr時Textからerr時Error variantに変更
- e2e testを更新
- authSliceを更新

<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
エラー取得時のユーザーへの通知方法の検討
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
main.mo
e2eテスト
redux-toolkitでのエラー状態管理
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
```
./script/install_local.sh
npm run test
```
が正常終了することを確認した
```
npm run start
```
でブラウザにてログイン処理ができることを確認した
<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足

<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
