### PR TITLE
Add feature for minting NFTs

### DIFF
--- a/src/NFTBarter_assets/src/App.tsx
+++ b/src/NFTBarter_assets/src/App.tsx
@@ -6,6 +6,7 @@ import { SampleLoginPage } from './features/auth/SampleLoginPage';
 
 import { Layout } from './Components/Layout';
 import { Profile } from './Components/Profile';
+import { NFTMint } from './Components/NFTMint';
 import { NotFound } from './Components/NotFound';
 
 export const App = () => {
@@ -16,6 +17,9 @@ export const App = () => {
           <Route path='/' element={<SampleLoginPage />} />
           <Route path='/profile' element={<PrivateRoute />}>
             <Route path='' element={<Profile />} />
+          </Route>
+          <Route path='/mint' element={<PrivateRoute />}>
+            <Route path='' element={<NFTMint />} />
           </Route>
           <Route path='*' element={<NotFound />} />
         </Routes>

--- a/src/NFTBarter_assets/src/Components/NFTCard.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTCard.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+import { Box, HStack, Image, Text } from '@chakra-ui/react';
+
+interface Props {
+  tokenId: string;
+  tokenIndex: number;
+  baseUrl: string;
+}
+
+export const NFTCard: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
+  return (
+    <Box width='200px' borderRadius='xl' borderWidth='1px' overflow='hidden'>
+      <Image
+        fit={'cover'}
+        width='100%'
+        alt={`${tokenId}`}
+        src={`${baseUrl}/?tokenid=${tokenId}`}
+      />
+      <Text
+        p={{ base: 2, lg: 3 }}
+        fontSize={{ base: 'xs', md: 'sm' }}
+      >{`# ${tokenIndex}`}</Text>
+    </Box>
+  );
+};

--- a/src/NFTBarter_assets/src/Components/NFTMint.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTMint.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Center, Button, Text } from '@chakra-ui/react';
+
+export const NFTMint = () => {
+  return (
+    <>
+      <Center h='80vh'>
+        <Button
+          color='white'
+          px='1em'
+          fontSize='md'
+          height='2.5em'
+          bgGradient='linear(to-r, blue.300, green.200)'
+          borderRadius='2xl'
+          _hover={{ bgGradient: 'linear(to-r, blue.400, green.300)' }}
+          onClick={async () => {}}
+        >
+          <Text fontWeight='semibold'>Mint</Text>
+        </Button>
+      </Center>
+    </>
+  );
+};

--- a/src/NFTBarter_assets/src/Components/NFTMint.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTMint.tsx
@@ -1,22 +1,31 @@
 import React from 'react';
-import { Center, Button, Text } from '@chakra-ui/react';
+import { Center, Text, VStack } from '@chakra-ui/react';
+import { useAppSelector } from '../app/hooks';
+
+import { MintButton } from '../features/mint/MintButton';
+import {
+  selectTokenId,
+  selectTokenIndex,
+  selectError,
+} from '../features/mint/mintSlice';
 
 export const NFTMint = () => {
+  const tokenId = useAppSelector(selectTokenId);
+  const tokenIndex = useAppSelector(selectTokenIndex);
+  const error = useAppSelector(selectError);
+
   return (
     <>
       <Center h='80vh'>
-        <Button
-          color='white'
-          px='1em'
-          fontSize='md'
-          height='2.5em'
-          bgGradient='linear(to-r, blue.300, green.200)'
-          borderRadius='2xl'
-          _hover={{ bgGradient: 'linear(to-r, blue.400, green.300)' }}
-          onClick={async () => {}}
-        >
-          <Text fontWeight='semibold'>Mint</Text>
-        </Button>
+        <VStack>
+          {tokenId && tokenIndex && (
+            <Text>
+              You minted #{tokenIndex} ({tokenId})
+            </Text>
+          )}
+          {error && <Text>{error}</Text>}
+          <MintButton />
+        </VStack>
       </Center>
     </>
   );

--- a/src/NFTBarter_assets/src/Components/Profile.tsx
+++ b/src/NFTBarter_assets/src/Components/Profile.tsx
@@ -3,6 +3,7 @@ import { Center, Box, HStack, Image, Text } from '@chakra-ui/react';
 import { useAppSelector } from '../app/hooks';
 import { selectPrincipal } from '../features/auth/authSlice';
 import { UserIcon } from './UserIcon';
+import { MyGenerativeArtNFTs } from '../features/myGenerativeArtNFT/MyGenerativeArtNFTs';
 
 const PrincipalID: FC<{ principal: string }> = ({ principal }) => {
   return (
@@ -46,6 +47,7 @@ export const Profile = () => {
         </Box>
         <Box mt='20'>{principal && <PrincipalID principal={principal} />}</Box>
       </Center>
+      <MyGenerativeArtNFTs />
       <Center h='60vh'></Center>
     </>
   );

--- a/src/NFTBarter_assets/src/app/store.ts
+++ b/src/NFTBarter_assets/src/app/store.ts
@@ -5,10 +5,12 @@ import {
   Dispatch,
 } from '@reduxjs/toolkit';
 import authReducer from '../features/auth/authSlice';
+import mintReducer from '../features/mint/mintSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    mint: mintReducer,
   },
 });
 

--- a/src/NFTBarter_assets/src/app/store.ts
+++ b/src/NFTBarter_assets/src/app/store.ts
@@ -6,11 +6,13 @@ import {
 } from '@reduxjs/toolkit';
 import authReducer from '../features/auth/authSlice';
 import mintReducer from '../features/mint/mintSlice';
+import myGenerativeArtNFTReducer from '../features/myGenerativeArtNFT/myGenerativeArtNFTSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     mint: mintReducer,
+    myGenerativeArtNFT: myGenerativeArtNFTReducer,
   },
 });
 

--- a/src/NFTBarter_assets/src/features/mint/MintButton.tsx
+++ b/src/NFTBarter_assets/src/features/mint/MintButton.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { Button, Text } from '@chakra-ui/react';
+
+import { useAppDispatch } from '../../app/hooks';
+import { mint } from './mintSlice';
+
+export const MintButton = () => {
+  const dispatch = useAppDispatch();
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    setLoading(true);
+    await dispatch(mint());
+    setLoading(false);
+  };
+
+  return (
+    <Button
+      color='white'
+      px='1em'
+      fontSize='md'
+      height='2.5em'
+      bgGradient='linear(to-r, blue.300, green.200)'
+      borderRadius='2xl'
+      _hover={{ bgGradient: 'linear(to-r, blue.400, green.300)' }}
+      disabled={loading}
+      onClick={handleClick}
+    >
+      <Text fontWeight='semibold'>Mint</Text>
+    </Button>
+  );
+};

--- a/src/NFTBarter_assets/src/features/mint/mintSlice.ts
+++ b/src/NFTBarter_assets/src/features/mint/mintSlice.ts
@@ -1,0 +1,78 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { AuthClient } from '@dfinity/auth-client';
+import { RootState, AsyncThunkConfig } from '../../app/store';
+import { generateTokenIdentifier } from '../../utils/ext';
+
+import {
+  User,
+  MintRequest,
+} from '../../../../declarations/GenerativeArtNFT/GenerativeArtNFT.did.js';
+import { createActor } from '../../../../declarations/GenerativeArtNFT';
+
+const canisterId =
+  process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
+    ? 'REPLACE_TO_CANISTER_ID'
+    : process.env.LOCAL_NFT_CANISTER_ID;
+
+export interface MintState {
+  tokenId?: string;
+  tokenIndex?: number;
+  error?: string;
+}
+
+const initialState: MintState = {};
+
+export const mint = createAsyncThunk<
+  MintState,
+  undefined,
+  AsyncThunkConfig<{ error: string }>
+>('mint/mintNFT', async (_, { rejectWithValue }) => {
+  const authClient = await AuthClient.create();
+
+  if (!authClient || !authClient.isAuthenticated()) {
+    return rejectWithValue({ error: 'Failed to use auth client.' });
+  }
+
+  const identity = await authClient.getIdentity();
+
+  const actor = createActor(canisterId, {
+    agentOptions: { identity },
+  });
+
+  const user: User = {
+    principal: identity.getPrincipal(),
+  };
+  const mintRequest: MintRequest = {
+    to: user,
+    metadata: [],
+  };
+
+  try {
+    const tokenIndex = await actor.mintNFT(mintRequest);
+    const tokenId = generateTokenIdentifier(canisterId, tokenIndex);
+    return { tokenId, tokenIndex };
+  } catch {
+    return rejectWithValue({ error: 'Mint failed.' });
+  }
+});
+
+export const mintSlice = createSlice({
+  name: 'mint',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(mint.fulfilled, (state, action) => {
+      state.tokenId = action.payload?.tokenId;
+      state.tokenIndex = action.payload?.tokenIndex;
+    });
+    builder.addCase(mint.rejected, (state, action) => {
+      state.error = action.payload?.error;
+    });
+  },
+});
+
+export const selectError = (state: RootState) => state.mint.error;
+export const selectTokenId = (state: RootState) => state.mint.tokenId;
+export const selectTokenIndex = (state: RootState) => state.mint.tokenIndex;
+
+export default mintSlice.reducer;

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect } from 'react';
+import { Box, SimpleGrid, Center } from '@chakra-ui/react';
+
+import { NFTCard } from './../../Components/NFTCard';
+
+const baseUrl =
+  process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
+    ? 'http://REPLACE_TO_CANISTER_ID.ic0.app'
+    : `http://${process.env.LOCAL_NFT_CANISTER_ID}.localhost:8000`;
+
+import { useAppSelector, useAppDispatch } from '../../app/hooks';
+import { fetchNFTs, selectNfts } from './myGenerativeArtNFTSlice';
+
+export const MyGenerativeArtNFTs = () => {
+  const dispatch = useAppDispatch();
+  const nfts = useAppSelector(selectNfts);
+
+  useEffect(() => {
+    dispatch(fetchNFTs());
+  }, []);
+
+  return (
+    <Box maxW='1300px' mx='auto' mt='20px'>
+      <SimpleGrid mx='10px' spacing='10px' columns={{ base: 2, md: 3, lg: 4 }}>
+        {nfts.map((nft) => {
+          const { tokenId, tokenIndex } = nft;
+          return (
+            <Center my='10px'>
+              <NFTCard
+                key={tokenIndex}
+                tokenId={tokenId}
+                tokenIndex={tokenIndex}
+                baseUrl={baseUrl}
+              />
+            </Center>
+          );
+        })}
+      </SimpleGrid>
+    </Box>
+  );
+};

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/myGenerativeArtNFTSlice.ts
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/myGenerativeArtNFTSlice.ts
@@ -1,0 +1,78 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { AuthClient } from '@dfinity/auth-client';
+import { RootState, AsyncThunkConfig } from '../../app/store';
+import { generateTokenIdentifier } from '../../utils/ext';
+
+import { User } from '../../../../declarations/GenerativeArtNFT/GenerativeArtNFT.did.js';
+import { createActor } from '../../../../declarations/GenerativeArtNFT';
+
+const canisterId =
+  process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
+    ? 'REPLACE_TO_CANISTER_ID'
+    : process.env.LOCAL_NFT_CANISTER_ID;
+
+export interface GenerativeArtNFT {
+  tokenId: string;
+  tokenIndex: number;
+}
+
+export interface MyGenerativeArtNFTState {
+  nfts: GenerativeArtNFT[];
+  error?: string;
+}
+
+const initialState: MyGenerativeArtNFTState = {
+  nfts: [],
+};
+
+export const fetchNFTs = createAsyncThunk<
+  MyGenerativeArtNFTState,
+  undefined,
+  AsyncThunkConfig<{ error: string }>
+>('myGenerativeArtNFT/fetchNFTs', async (_, { rejectWithValue }) => {
+  const authClient = await AuthClient.create();
+
+  if (!authClient || !authClient.isAuthenticated()) {
+    return rejectWithValue({ error: 'Failed to use auth client.' });
+  }
+
+  const identity = await authClient.getIdentity();
+
+  const actor = createActor(canisterId, {
+    agentOptions: { identity },
+  });
+
+  const user: User = {
+    principal: identity.getPrincipal(),
+  };
+
+  try {
+    return {
+      nfts: (await actor.getTokenIndexOwnedByUser(user)).map((tokenIndex) => {
+        const tokenId = generateTokenIdentifier(canisterId, tokenIndex);
+        return { tokenId, tokenIndex };
+      }),
+    };
+  } catch {
+    return rejectWithValue({ error: 'Mint failed.' });
+  }
+});
+
+export const myGenerativeArtNFTSlice = createSlice({
+  name: 'myGenerativeArtNFT',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchNFTs.fulfilled, (state, action) => {
+      state.nfts = action.payload?.nfts;
+    });
+    builder.addCase(fetchNFTs.rejected, (state, action) => {
+      state.error = action.payload?.error;
+    });
+  },
+});
+
+export const selectError = (state: RootState) => state.myGenerativeArtNFT.error;
+export const selectNfts = (state: RootState) => state.myGenerativeArtNFT.nfts;
+
+export default myGenerativeArtNFTSlice.reducer;

--- a/src/NFTBarter_assets/src/utils/ext.ts
+++ b/src/NFTBarter_assets/src/utils/ext.ts
@@ -1,0 +1,24 @@
+import { Principal } from '@dfinity/principal';
+
+export const generateTokenIdentifier = (
+  principal: string,
+  index: number
+): string => {
+  const padding = Buffer.from('\x0Atid');
+  const array = new Uint8Array([
+    ...padding,
+    ...Principal.fromText(principal).toUint8Array(),
+    ...numberTo32bits(index),
+  ]);
+  return Principal.fromUint8Array(array).toText();
+};
+
+export const getSubAccount = (index: number): number[] => {
+  return Array(28).fill(0).concat(numberTo32bits(index));
+};
+
+const numberTo32bits = (num: number) => {
+  let b = new ArrayBuffer(4);
+  new DataView(b).setUint32(0, num);
+  return Array.from(new Uint8Array(b));
+};

--- a/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did
+++ b/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did
@@ -118,6 +118,7 @@ type GenerativeArtNFT =
    supply: (TokenIdentifier__1) -> (Result_1) query;
    transfer: (TransferRequest) -> (TransferResponse);
    updateTokenImageSetter: (principal) -> (Result);
+   getTokenIndexOwnedByUser: (User__1) -> (vec TokenIndex) query;
  };
 type Extension = text;
 type CommonError__1 = 

--- a/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did
+++ b/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did
@@ -1,0 +1,160 @@
+type User = 
+ variant {
+   address: AccountIdentifier;
+   "principal": principal;
+ };
+type TransferResponse = 
+ variant {
+   err:
+    variant {
+      CannotNotify: AccountIdentifier;
+      InsufficientBalance;
+      InvalidToken: TokenIdentifier;
+      Other: text;
+      Rejected;
+      Unauthorized: AccountIdentifier;
+    };
+   ok: Balance;
+ };
+type TransferRequest = 
+ record {
+   amount: Balance;
+   from: User;
+   memo: Memo;
+   notify: bool;
+   subaccount: opt SubAccount;
+   to: User;
+   token: TokenIdentifier;
+ };
+type TokenIndex = nat32;
+type TokenIdentifier__1 = text;
+type TokenIdentifier = text;
+type SubAccount = vec nat8;
+type Result_3 = 
+ variant {
+   err: CommonError;
+   ok: AccountIdentifier__1;
+ };
+type Result_2 = 
+ variant {
+   err: CommonError;
+   ok: Metadata;
+ };
+type Result_1 = 
+ variant {
+   err: CommonError;
+   ok: Balance__1;
+ };
+type Result = 
+ variant {
+   err: CommonError;
+   ok;
+ };
+type MintRequest = 
+ record {
+   metadata: opt blob;
+   to: User;
+ };
+type Metadata = 
+ variant {
+   fungible:
+    record {
+      decimals: nat8;
+      metadata: opt blob;
+      name: text;
+      symbol: text;
+    };
+   nonfungible: record {metadata: opt blob;};
+ };
+type Memo = blob;
+type HttpResponse = 
+ record {
+   body: blob;
+   headers: vec HeaderField;
+   status_code: nat16;
+ };
+type HttpRequest = 
+ record {
+   body: blob;
+   headers: vec HeaderField;
+   method: text;
+   url: text;
+ };
+type HeaderField = 
+ record {
+   text;
+   text;
+ };
+type GenerativeArtNFT = 
+ service {
+   acceptCycles: () -> ();
+   allowance: (AllowanceRequest) -> (Result_1) query;
+   approve: (ApproveRequest) -> ();
+   availableCycles: () -> (nat) query;
+   balance: (BalanceRequest) -> (BalanceResponse) query;
+   bearer: (TokenIdentifier__1) -> (Result_3) query;
+   extensions: () -> (vec Extension) query;
+   getAllowances: () -> (vec record {
+                               TokenIndex;
+                               principal;
+                             }) query;
+   getInstaller: () -> (text);
+   getRegistry: () -> (vec record {
+                             TokenIndex;
+                             AccountIdentifier__1;
+                           }) query;
+   getTokenImages: () -> (vec record {
+                                TokenIndex;
+                                blob;
+                              }) query;
+   getTokens: () -> (vec record {
+                           TokenIndex;
+                           Metadata;
+                         }) query;
+   http_request: (HttpRequest) -> (HttpResponse) query;
+   metadata: (TokenIdentifier__1) -> (Result_2) query;
+   mintNFT: (MintRequest) -> (TokenIndex);
+   setTokenImage: (TokenIndex, text) -> (Result);
+   supply: (TokenIdentifier__1) -> (Result_1) query;
+   transfer: (TransferRequest) -> (TransferResponse);
+   updateTokenImageSetter: (principal) -> (Result);
+ };
+type Extension = text;
+type CommonError__1 = 
+ variant {
+   InvalidToken: TokenIdentifier;
+   Other: text;
+ };
+type CommonError = 
+ variant {
+   InvalidToken: TokenIdentifier;
+   Other: text;
+ };
+type Balance__1 = nat;
+type BalanceResponse = 
+ variant {
+   err: CommonError__1;
+   ok: Balance;
+ };
+type BalanceRequest = 
+ record {
+   token: TokenIdentifier;
+   user: User;
+ };
+type Balance = nat;
+type ApproveRequest = 
+ record {
+   allowance: Balance;
+   spender: principal;
+   subaccount: opt SubAccount;
+   token: TokenIdentifier;
+ };
+type AllowanceRequest = 
+ record {
+   owner: User;
+   spender: principal;
+   token: TokenIdentifier;
+ };
+type AccountIdentifier__1 = text;
+type AccountIdentifier = text;
+service : () -> GenerativeArtNFT

--- a/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.d.ts
+++ b/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.d.ts
@@ -1,0 +1,106 @@
+import type { Principal } from '@dfinity/principal';
+import { IDL } from '@dfinity/candid';
+export type AccountIdentifier = string;
+export type AccountIdentifier__1 = string;
+export interface AllowanceRequest {
+  token: TokenIdentifier;
+  owner: User;
+  spender: Principal;
+}
+export interface ApproveRequest {
+  token: TokenIdentifier;
+  subaccount: [] | [SubAccount];
+  allowance: Balance;
+  spender: Principal;
+}
+export type Balance = bigint;
+export interface BalanceRequest {
+  token: TokenIdentifier;
+  user: User;
+}
+export type BalanceResponse = { ok: Balance } | { err: CommonError__1 };
+export type Balance__1 = bigint;
+export type CommonError = { InvalidToken: TokenIdentifier } | { Other: string };
+export type CommonError__1 =
+  | { InvalidToken: TokenIdentifier }
+  | { Other: string };
+export type Extension = string;
+export interface GenerativeArtNFT {
+  acceptCycles: () => Promise<undefined>;
+  allowance: (arg_0: AllowanceRequest) => Promise<Result_1>;
+  approve: (arg_0: ApproveRequest) => Promise<undefined>;
+  availableCycles: () => Promise<bigint>;
+  balance: (arg_0: BalanceRequest) => Promise<BalanceResponse>;
+  bearer: (arg_0: TokenIdentifier__1) => Promise<Result_3>;
+  extensions: () => Promise<Array<Extension>>;
+  getAllowances: () => Promise<Array<[TokenIndex, Principal]>>;
+  getInstaller: () => Promise<string>;
+  getRegistry: () => Promise<Array<[TokenIndex, AccountIdentifier__1]>>;
+  getTokenImages: () => Promise<Array<[TokenIndex, Array<number>]>>;
+  getTokens: () => Promise<Array<[TokenIndex, Metadata]>>;
+  http_request: (arg_0: HttpRequest) => Promise<HttpResponse>;
+  metadata: (arg_0: TokenIdentifier__1) => Promise<Result_2>;
+  mintNFT: (arg_0: MintRequest) => Promise<TokenIndex>;
+  setTokenImage: (arg_0: TokenIndex, arg_1: string) => Promise<Result>;
+  supply: (arg_0: TokenIdentifier__1) => Promise<Result_1>;
+  transfer: (arg_0: TransferRequest) => Promise<TransferResponse>;
+  updateTokenImageSetter: (arg_0: Principal) => Promise<Result>;
+}
+export type HeaderField = [string, string];
+export interface HttpRequest {
+  url: string;
+  method: string;
+  body: Array<number>;
+  headers: Array<HeaderField>;
+}
+export interface HttpResponse {
+  body: Array<number>;
+  headers: Array<HeaderField>;
+  status_code: number;
+}
+export type Memo = Array<number>;
+export type Metadata =
+  | {
+      fungible: {
+        decimals: number;
+        metadata: [] | [Array<number>];
+        name: string;
+        symbol: string;
+      };
+    }
+  | { nonfungible: { metadata: [] | [Array<number>] } };
+export interface MintRequest {
+  to: User;
+  metadata: [] | [Array<number>];
+}
+export type Result = { ok: null } | { err: CommonError };
+export type Result_1 = { ok: Balance__1 } | { err: CommonError };
+export type Result_2 = { ok: Metadata } | { err: CommonError };
+export type Result_3 = { ok: AccountIdentifier__1 } | { err: CommonError };
+export type SubAccount = Array<number>;
+export type TokenIdentifier = string;
+export type TokenIdentifier__1 = string;
+export type TokenIndex = number;
+export interface TransferRequest {
+  to: User;
+  token: TokenIdentifier;
+  notify: boolean;
+  from: User;
+  memo: Memo;
+  subaccount: [] | [SubAccount];
+  amount: Balance;
+}
+export type TransferResponse =
+  | { ok: Balance }
+  | {
+      err:
+        | { CannotNotify: AccountIdentifier }
+        | { InsufficientBalance: null }
+        | { InvalidToken: TokenIdentifier }
+        | { Rejected: null }
+        | { Unauthorized: AccountIdentifier }
+        | { Other: string };
+    };
+export type User = { principal: Principal } | { address: AccountIdentifier };
+export interface _SERVICE extends GenerativeArtNFT {}
+export function idlFactory(): IDL.ServiceClass;

--- a/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.d.ts
+++ b/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.d.ts
@@ -45,6 +45,7 @@ export interface GenerativeArtNFT {
   supply: (arg_0: TokenIdentifier__1) => Promise<Result_1>;
   transfer: (arg_0: TransferRequest) => Promise<TransferResponse>;
   updateTokenImageSetter: (arg_0: Principal) => Promise<Result>;
+  getTokenIndexOwnedByUser: (arg_0: User) => Promise<Array<TokenIndex>>;
 }
 export type HeaderField = [string, string];
 export interface HttpRequest {

--- a/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.js
+++ b/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.js
@@ -2,133 +2,140 @@ export const idlFactory = ({ IDL }) => {
   const TokenIdentifier = IDL.Text;
   const AccountIdentifier = IDL.Text;
   const User = IDL.Variant({
-    'principal' : IDL.Principal,
-    'address' : AccountIdentifier,
+    principal: IDL.Principal,
+    address: AccountIdentifier,
   });
   const AllowanceRequest = IDL.Record({
-    'token' : TokenIdentifier,
-    'owner' : User,
-    'spender' : IDL.Principal,
+    token: TokenIdentifier,
+    owner: User,
+    spender: IDL.Principal,
   });
   const Balance__1 = IDL.Nat;
   const CommonError = IDL.Variant({
-    'InvalidToken' : TokenIdentifier,
-    'Other' : IDL.Text,
+    InvalidToken: TokenIdentifier,
+    Other: IDL.Text,
   });
-  const Result_1 = IDL.Variant({ 'ok' : Balance__1, 'err' : CommonError });
+  const Result_1 = IDL.Variant({ ok: Balance__1, err: CommonError });
   const SubAccount = IDL.Vec(IDL.Nat8);
   const Balance = IDL.Nat;
   const ApproveRequest = IDL.Record({
-    'token' : TokenIdentifier,
-    'subaccount' : IDL.Opt(SubAccount),
-    'allowance' : Balance,
-    'spender' : IDL.Principal,
+    token: TokenIdentifier,
+    subaccount: IDL.Opt(SubAccount),
+    allowance: Balance,
+    spender: IDL.Principal,
   });
   const BalanceRequest = IDL.Record({
-    'token' : TokenIdentifier,
-    'user' : User,
+    token: TokenIdentifier,
+    user: User,
   });
   const CommonError__1 = IDL.Variant({
-    'InvalidToken' : TokenIdentifier,
-    'Other' : IDL.Text,
+    InvalidToken: TokenIdentifier,
+    Other: IDL.Text,
   });
   const BalanceResponse = IDL.Variant({
-    'ok' : Balance,
-    'err' : CommonError__1,
+    ok: Balance,
+    err: CommonError__1,
   });
   const TokenIdentifier__1 = IDL.Text;
   const AccountIdentifier__1 = IDL.Text;
   const Result_3 = IDL.Variant({
-    'ok' : AccountIdentifier__1,
-    'err' : CommonError,
+    ok: AccountIdentifier__1,
+    err: CommonError,
   });
   const Extension = IDL.Text;
   const TokenIndex = IDL.Nat32;
   const Metadata = IDL.Variant({
-    'fungible' : IDL.Record({
-      'decimals' : IDL.Nat8,
-      'metadata' : IDL.Opt(IDL.Vec(IDL.Nat8)),
-      'name' : IDL.Text,
-      'symbol' : IDL.Text,
+    fungible: IDL.Record({
+      decimals: IDL.Nat8,
+      metadata: IDL.Opt(IDL.Vec(IDL.Nat8)),
+      name: IDL.Text,
+      symbol: IDL.Text,
     }),
-    'nonfungible' : IDL.Record({ 'metadata' : IDL.Opt(IDL.Vec(IDL.Nat8)) }),
+    nonfungible: IDL.Record({ metadata: IDL.Opt(IDL.Vec(IDL.Nat8)) }),
   });
   const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
   const HttpRequest = IDL.Record({
-    'url' : IDL.Text,
-    'method' : IDL.Text,
-    'body' : IDL.Vec(IDL.Nat8),
-    'headers' : IDL.Vec(HeaderField),
+    url: IDL.Text,
+    method: IDL.Text,
+    body: IDL.Vec(IDL.Nat8),
+    headers: IDL.Vec(HeaderField),
   });
   const HttpResponse = IDL.Record({
-    'body' : IDL.Vec(IDL.Nat8),
-    'headers' : IDL.Vec(HeaderField),
-    'status_code' : IDL.Nat16,
+    body: IDL.Vec(IDL.Nat8),
+    headers: IDL.Vec(HeaderField),
+    status_code: IDL.Nat16,
   });
-  const Result_2 = IDL.Variant({ 'ok' : Metadata, 'err' : CommonError });
+  const Result_2 = IDL.Variant({ ok: Metadata, err: CommonError });
   const MintRequest = IDL.Record({
-    'to' : User,
-    'metadata' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    to: User,
+    metadata: IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
-  const Result = IDL.Variant({ 'ok' : IDL.Null, 'err' : CommonError });
+  const Result = IDL.Variant({ ok: IDL.Null, err: CommonError });
   const Memo = IDL.Vec(IDL.Nat8);
   const TransferRequest = IDL.Record({
-    'to' : User,
-    'token' : TokenIdentifier,
-    'notify' : IDL.Bool,
-    'from' : User,
-    'memo' : Memo,
-    'subaccount' : IDL.Opt(SubAccount),
-    'amount' : Balance,
+    to: User,
+    token: TokenIdentifier,
+    notify: IDL.Bool,
+    from: User,
+    memo: Memo,
+    subaccount: IDL.Opt(SubAccount),
+    amount: Balance,
   });
   const TransferResponse = IDL.Variant({
-    'ok' : Balance,
-    'err' : IDL.Variant({
-      'CannotNotify' : AccountIdentifier,
-      'InsufficientBalance' : IDL.Null,
-      'InvalidToken' : TokenIdentifier,
-      'Rejected' : IDL.Null,
-      'Unauthorized' : AccountIdentifier,
-      'Other' : IDL.Text,
+    ok: Balance,
+    err: IDL.Variant({
+      CannotNotify: AccountIdentifier,
+      InsufficientBalance: IDL.Null,
+      InvalidToken: TokenIdentifier,
+      Rejected: IDL.Null,
+      Unauthorized: AccountIdentifier,
+      Other: IDL.Text,
     }),
   });
   const GenerativeArtNFT = IDL.Service({
-    'acceptCycles' : IDL.Func([], [], []),
-    'allowance' : IDL.Func([AllowanceRequest], [Result_1], ['query']),
-    'approve' : IDL.Func([ApproveRequest], [], []),
-    'availableCycles' : IDL.Func([], [IDL.Nat], ['query']),
-    'balance' : IDL.Func([BalanceRequest], [BalanceResponse], ['query']),
-    'bearer' : IDL.Func([TokenIdentifier__1], [Result_3], ['query']),
-    'extensions' : IDL.Func([], [IDL.Vec(Extension)], ['query']),
-    'getAllowances' : IDL.Func(
-        [],
-        [IDL.Vec(IDL.Tuple(TokenIndex, IDL.Principal))],
-        ['query'],
-      ),
-    'getInstaller' : IDL.Func([], [IDL.Text], []),
-    'getRegistry' : IDL.Func(
-        [],
-        [IDL.Vec(IDL.Tuple(TokenIndex, AccountIdentifier__1))],
-        ['query'],
-      ),
-    'getTokenImages' : IDL.Func(
-        [],
-        [IDL.Vec(IDL.Tuple(TokenIndex, IDL.Vec(IDL.Nat8)))],
-        ['query'],
-      ),
-    'getTokens' : IDL.Func(
-        [],
-        [IDL.Vec(IDL.Tuple(TokenIndex, Metadata))],
-        ['query'],
-      ),
-    'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
-    'metadata' : IDL.Func([TokenIdentifier__1], [Result_2], ['query']),
-    'mintNFT' : IDL.Func([MintRequest], [TokenIndex], []),
-    'setTokenImage' : IDL.Func([TokenIndex, IDL.Text], [Result], []),
-    'supply' : IDL.Func([TokenIdentifier__1], [Result_1], ['query']),
-    'transfer' : IDL.Func([TransferRequest], [TransferResponse], []),
-    'updateTokenImageSetter' : IDL.Func([IDL.Principal], [Result], []),
+    acceptCycles: IDL.Func([], [], []),
+    allowance: IDL.Func([AllowanceRequest], [Result_1], ['query']),
+    approve: IDL.Func([ApproveRequest], [], []),
+    availableCycles: IDL.Func([], [IDL.Nat], ['query']),
+    balance: IDL.Func([BalanceRequest], [BalanceResponse], ['query']),
+    bearer: IDL.Func([TokenIdentifier__1], [Result_3], ['query']),
+    extensions: IDL.Func([], [IDL.Vec(Extension)], ['query']),
+    getAllowances: IDL.Func(
+      [],
+      [IDL.Vec(IDL.Tuple(TokenIndex, IDL.Principal))],
+      ['query']
+    ),
+    getInstaller: IDL.Func([], [IDL.Text], []),
+    getRegistry: IDL.Func(
+      [],
+      [IDL.Vec(IDL.Tuple(TokenIndex, AccountIdentifier__1))],
+      ['query']
+    ),
+    getTokenImages: IDL.Func(
+      [],
+      [IDL.Vec(IDL.Tuple(TokenIndex, IDL.Vec(IDL.Nat8)))],
+      ['query']
+    ),
+    getTokens: IDL.Func(
+      [],
+      [IDL.Vec(IDL.Tuple(TokenIndex, Metadata))],
+      ['query']
+    ),
+    http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
+    metadata: IDL.Func([TokenIdentifier__1], [Result_2], ['query']),
+    mintNFT: IDL.Func([MintRequest], [TokenIndex], []),
+    setTokenImage: IDL.Func([TokenIndex, IDL.Text], [Result], []),
+    supply: IDL.Func([TokenIdentifier__1], [Result_1], ['query']),
+    transfer: IDL.Func([TransferRequest], [TransferResponse], []),
+    updateTokenImageSetter: IDL.Func([IDL.Principal], [Result], []),
+    getTokenIndexOwnedByUser: IDL.Func(
+      [User],
+      [IDL.Vec(TokenIndex)],
+      ['query']
+    ),
   });
   return GenerativeArtNFT;
 };
-export const init = ({ IDL }) => { return []; };
+export const init = ({ IDL }) => {
+  return [];
+};

--- a/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.js
+++ b/src/declarations/GenerativeArtNFT/GenerativeArtNFT.did.js
@@ -1,0 +1,134 @@
+export const idlFactory = ({ IDL }) => {
+  const TokenIdentifier = IDL.Text;
+  const AccountIdentifier = IDL.Text;
+  const User = IDL.Variant({
+    'principal' : IDL.Principal,
+    'address' : AccountIdentifier,
+  });
+  const AllowanceRequest = IDL.Record({
+    'token' : TokenIdentifier,
+    'owner' : User,
+    'spender' : IDL.Principal,
+  });
+  const Balance__1 = IDL.Nat;
+  const CommonError = IDL.Variant({
+    'InvalidToken' : TokenIdentifier,
+    'Other' : IDL.Text,
+  });
+  const Result_1 = IDL.Variant({ 'ok' : Balance__1, 'err' : CommonError });
+  const SubAccount = IDL.Vec(IDL.Nat8);
+  const Balance = IDL.Nat;
+  const ApproveRequest = IDL.Record({
+    'token' : TokenIdentifier,
+    'subaccount' : IDL.Opt(SubAccount),
+    'allowance' : Balance,
+    'spender' : IDL.Principal,
+  });
+  const BalanceRequest = IDL.Record({
+    'token' : TokenIdentifier,
+    'user' : User,
+  });
+  const CommonError__1 = IDL.Variant({
+    'InvalidToken' : TokenIdentifier,
+    'Other' : IDL.Text,
+  });
+  const BalanceResponse = IDL.Variant({
+    'ok' : Balance,
+    'err' : CommonError__1,
+  });
+  const TokenIdentifier__1 = IDL.Text;
+  const AccountIdentifier__1 = IDL.Text;
+  const Result_3 = IDL.Variant({
+    'ok' : AccountIdentifier__1,
+    'err' : CommonError,
+  });
+  const Extension = IDL.Text;
+  const TokenIndex = IDL.Nat32;
+  const Metadata = IDL.Variant({
+    'fungible' : IDL.Record({
+      'decimals' : IDL.Nat8,
+      'metadata' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+      'name' : IDL.Text,
+      'symbol' : IDL.Text,
+    }),
+    'nonfungible' : IDL.Record({ 'metadata' : IDL.Opt(IDL.Vec(IDL.Nat8)) }),
+  });
+  const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
+  const HttpRequest = IDL.Record({
+    'url' : IDL.Text,
+    'method' : IDL.Text,
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+  });
+  const HttpResponse = IDL.Record({
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+    'status_code' : IDL.Nat16,
+  });
+  const Result_2 = IDL.Variant({ 'ok' : Metadata, 'err' : CommonError });
+  const MintRequest = IDL.Record({
+    'to' : User,
+    'metadata' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const Result = IDL.Variant({ 'ok' : IDL.Null, 'err' : CommonError });
+  const Memo = IDL.Vec(IDL.Nat8);
+  const TransferRequest = IDL.Record({
+    'to' : User,
+    'token' : TokenIdentifier,
+    'notify' : IDL.Bool,
+    'from' : User,
+    'memo' : Memo,
+    'subaccount' : IDL.Opt(SubAccount),
+    'amount' : Balance,
+  });
+  const TransferResponse = IDL.Variant({
+    'ok' : Balance,
+    'err' : IDL.Variant({
+      'CannotNotify' : AccountIdentifier,
+      'InsufficientBalance' : IDL.Null,
+      'InvalidToken' : TokenIdentifier,
+      'Rejected' : IDL.Null,
+      'Unauthorized' : AccountIdentifier,
+      'Other' : IDL.Text,
+    }),
+  });
+  const GenerativeArtNFT = IDL.Service({
+    'acceptCycles' : IDL.Func([], [], []),
+    'allowance' : IDL.Func([AllowanceRequest], [Result_1], ['query']),
+    'approve' : IDL.Func([ApproveRequest], [], []),
+    'availableCycles' : IDL.Func([], [IDL.Nat], ['query']),
+    'balance' : IDL.Func([BalanceRequest], [BalanceResponse], ['query']),
+    'bearer' : IDL.Func([TokenIdentifier__1], [Result_3], ['query']),
+    'extensions' : IDL.Func([], [IDL.Vec(Extension)], ['query']),
+    'getAllowances' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(TokenIndex, IDL.Principal))],
+        ['query'],
+      ),
+    'getInstaller' : IDL.Func([], [IDL.Text], []),
+    'getRegistry' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(TokenIndex, AccountIdentifier__1))],
+        ['query'],
+      ),
+    'getTokenImages' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(TokenIndex, IDL.Vec(IDL.Nat8)))],
+        ['query'],
+      ),
+    'getTokens' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(TokenIndex, Metadata))],
+        ['query'],
+      ),
+    'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
+    'metadata' : IDL.Func([TokenIdentifier__1], [Result_2], ['query']),
+    'mintNFT' : IDL.Func([MintRequest], [TokenIndex], []),
+    'setTokenImage' : IDL.Func([TokenIndex, IDL.Text], [Result], []),
+    'supply' : IDL.Func([TokenIdentifier__1], [Result_1], ['query']),
+    'transfer' : IDL.Func([TransferRequest], [TransferResponse], []),
+    'updateTokenImageSetter' : IDL.Func([IDL.Principal], [Result], []),
+  });
+  return GenerativeArtNFT;
+};
+export const init = ({ IDL }) => { return []; };

--- a/src/declarations/GenerativeArtNFT/index.js
+++ b/src/declarations/GenerativeArtNFT/index.js
@@ -1,0 +1,32 @@
+import { Actor, HttpAgent } from '@dfinity/agent';
+
+// Imports and re-exports candid interface
+import { idlFactory } from './GenerativeArtNFT.did.js';
+export { idlFactory } from './GenerativeArtNFT.did.js';
+
+/**
+ *
+ * @param {string | import("@dfinity/principal").Principal} canisterId Canister ID of Agent
+ * @param {{agentOptions?: import("@dfinity/agent").HttpAgentOptions; actorOptions?: import("@dfinity/agent").ActorConfig}} [options]
+ * @return {import("@dfinity/agent").ActorSubclass<import("./GenerativeArtNFT.did.js")._SERVICE>}
+ */
+export const createActor = (canisterId, options) => {
+  const agent = new HttpAgent({ ...options?.agentOptions });
+
+  // Fetch root key for certificate validation during development
+  if (process.env.NODE_ENV !== 'production') {
+    agent.fetchRootKey().catch((err) => {
+      console.warn(
+        'Unable to fetch root key. Check to ensure that your local replica is running'
+      );
+      console.error(err);
+    });
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor(idlFactory, {
+    agent,
+    canisterId,
+    ...options?.actorOptions,
+  });
+};

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -14,6 +14,7 @@ const env = dotenv.config().parsed;
 const LOCAL_II_CANISTER = `http://${
   env && process.env.LOCAL_II_CANISTER_ID
 }.localhost:8000/#authorize`;
+const LOCAL_NFT_CANISTER_ID = process.env.LOCAL_NFT_CANISTER_ID;
 
 function initCanisterEnv() {
   let localCanisters, prodCanisters;
@@ -102,6 +103,7 @@ module.exports = {
       NODE_ENV: 'development',
       DFX_NETWORK: network,
       LOCAL_II_CANISTER,
+      LOCAL_NFT_CANISTER_ID,
       ...canisterEnvVariables,
     }),
     new webpack.ProvidePlugin({

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -14,7 +14,7 @@ const env = dotenv.config().parsed;
 const LOCAL_II_CANISTER = `http://${
   env && process.env.LOCAL_II_CANISTER_ID
 }.localhost:8000/#authorize`;
-const LOCAL_NFT_CANISTER_ID = process.env.LOCAL_NFT_CANISTER_ID;
+const LOCAL_NFT_CANISTER_ID = env ? process.env.LOCAL_NFT_CANISTER_ID : '';
 
 function initCanisterEnv() {
   let localCanisters, prodCanisters;


### PR DESCRIPTION
# 概要・目的
フロントエンドからNFTのミントを可能にする
<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
Fixes #58 

# 変更内容
## やったこと
- NFTミントのページを作成する（ひとまずボタンだけ）https://github.com/Japan-DfinityInfoHub/nft-barter/commit/30f9a59dea23f98da04a0a2f055fffe924259376
- mintのためのfeatureを作成 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/7e1a7fdfd456acaa30281aa0166cbb4a6bfb1cc9
- ボタンが押されるとミントされる https://github.com/Japan-DfinityInfoHub/nft-barter/commit/22f3544f5415779ec7b998337862457b1620a05a
- ミント済みのNFTがプロフィール画面で確認できる（画像表示まで実装）https://github.com/Japan-DfinityInfoHub/nft-barter/commit/0d234631fd26ad8bdb525e0c3b20c0316ebcce4a
<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
- NFTの詳細ページの作成
- 各ページへのリンク
- ミント時の画像表示
- READMEの改修（GenerativeArtNFT Canister との連携）
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
フロントエンド
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
事前にGenerativeArtNFT Canister をローカルにデプロイしておき、適当な枚数の画像をCanisterでアップロードする。
.envファイルに`LOCAL_NFT_CANISTER_ID`（GenerativeArtNFT Canister ID）を追加する
```diff
LOCAL_II_CANISTER_ID=tmxop-wyaaa-aaaaa-aaapa-cai
+ LOCAL_NFT_CANISTER_ID=wqmuk-5qaaa-aaaaa-aaaqq-cai
```
```
npm run start
```
で立ち上げ、ログイン後
http://localhost:8080/mint
を開いてMintボタンを押すとミントされる（今は文字だけ）
![You minted #23 (kj7q2-xikor-uwiaa-aaaaa-aaaae-eaqca-aaaal-q)](https://user-images.githubusercontent.com/40290137/170867379-8fa81d64-781e-4ccf-9529-927d12702070.png)

続いて
http://localhost:8080/profile
を開くとミントしたNFTの画像一覧が表示される
![image](https://user-images.githubusercontent.com/40290137/170867482-57e9425a-7cc7-478c-962e-01c5f43afc2d.png)

<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足

<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
