### PR TITLE
Add NFT detail page

### DIFF
--- a/src/NFTBarter_assets/src/App.tsx
+++ b/src/NFTBarter_assets/src/App.tsx
@@ -8,6 +8,7 @@ import { SampleLoginPage } from './features/auth/SampleLoginPage';
 
 import { Profile } from './Components/Profile';
 import { NFTMint } from './Components/NFTMint';
+import { NFTDetail } from './Components/NFTDetail';
 import { NotFound } from './Components/NotFound';
 
 export const App = () => {
@@ -22,6 +23,9 @@ export const App = () => {
         </Route>
         <Route path='/mint' element={<PrivateRoute />}>
           <Route path='' element={<NFTMint />} />
+        </Route>
+        <Route path='/asset' element={<PublicRoute />}>
+          <Route path=':tokenId' element={<NFTDetail />} />
         </Route>
         <Route path='*' element={<PublicRoute />}>
           <Route path='' element={<NotFound />} />

--- a/src/NFTBarter_assets/src/Components/Menu.tsx
+++ b/src/NFTBarter_assets/src/Components/Menu.tsx
@@ -13,12 +13,13 @@ import logoutIcon from '@iconify/icons-material-symbols/logout';
 import createIcon from '@iconify/icons-gridicons/create';
 import userOutlined from '@iconify/icons-ant-design/user-outlined';
 
-import { useAppDispatch } from '../app/hooks';
-import { logout } from '../features/auth/authSlice';
+import { useAppDispatch, useAppSelector } from '../app/hooks';
+import { logout, selectAccountId } from '../features/auth/authSlice';
 import { UserIcon } from './UserIcon';
 
 export const Menu = () => {
   const dispatch = useAppDispatch();
+  const accountId = useAppSelector(selectAccountId);
 
   const iconSize = 28;
   const fontSize = 'md';
@@ -30,7 +31,7 @@ export const Menu = () => {
   return (
     <MenuChakra>
       <MenuButton>
-        <UserIcon diameter={40} />
+        <UserIcon diameter={40} accountId={accountId} />
       </MenuButton>
       <MenuList>
         <Link to='/profile'>

--- a/src/NFTBarter_assets/src/Components/NFTCard.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTCard.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Box, HStack, Image, Text } from '@chakra-ui/react';
+import { Box, Image, Text } from '@chakra-ui/react';
 
 interface Props {
   tokenId: string;

--- a/src/NFTBarter_assets/src/Components/NFTDetail.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTDetail.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { Center } from '@chakra-ui/react';
+
+export const NFTDetail = () => {
+  const params = useParams();
+  const tokenId = params.tokenId;
+
+  return <Center h='80vh'>{tokenId}</Center>;
+};

--- a/src/NFTBarter_assets/src/Components/NFTDetail.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTDetail.tsx
@@ -37,7 +37,7 @@ export const NFTDetail = () => {
   const { index, canisterId } = decodeTokenId(tokenId);
 
   // So far we only accept GenerativeArtNFT canister
-  if (canisterId && canisterId !== GENERATIVE_ART_NFT_CANISTER_ID) {
+  if (canisterId !== GENERATIVE_ART_NFT_CANISTER_ID) {
     return <NotFound />;
   }
 

--- a/src/NFTBarter_assets/src/Components/NFTDetail.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTDetail.tsx
@@ -3,11 +3,7 @@ import { useParams } from 'react-router-dom';
 import { Center } from '@chakra-ui/react';
 import { decodeTokenId } from '../utils/ext';
 import { NotFound } from './NotFound';
-
-const CANISTER_ID =
-  process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
-    ? 'REPLACE_TO_CANISTER_ID'
-    : process.env.LOCAL_NFT_CANISTER_ID;
+import { GENERATIVE_ART_NFT_CANISTER_ID } from '../utils/canisterId';
 
 export const NFTDetail = () => {
   const params = useParams();
@@ -19,7 +15,7 @@ export const NFTDetail = () => {
   const { canisterId } = decodeTokenId(tokenId);
 
   // So far we only accept GenerativeArtNFT canister
-  if (canisterId !== CANISTER_ID) {
+  if (canisterId !== GENERATIVE_ART_NFT_CANISTER_ID) {
     return <NotFound />;
   }
 

--- a/src/NFTBarter_assets/src/Components/NFTDetail.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTDetail.tsx
@@ -28,30 +28,28 @@ const getStack = () => {
 };
 
 export const NFTDetail = () => {
-  const params = useParams();
-  const tokenId = params.tokenId;
-  if (!tokenId) {
-    return <NotFound />;
-  }
-
+  const Stack = getStack();
+  const { tokenId } = useParams();
   const { index, canisterId } = decodeTokenId(tokenId);
 
   // So far we only accept GenerativeArtNFT canister
-  if (canisterId !== GENERATIVE_ART_NFT_CANISTER_ID) {
+  if (canisterId && canisterId !== GENERATIVE_ART_NFT_CANISTER_ID) {
     return <NotFound />;
   }
 
-  const Stack = getStack();
-
   return (
     <>
-      <Stack maxW='1300px' mx='auto' alignItems='flex-start'>
+      <Stack
+        maxW='1300px'
+        mx='auto'
+        alignItems={{ base: 'center', sm: 'flex-start' }}
+      >
         <Center
           width={{ base: '100%', sm: '40%' }}
           borderRadius='lg'
           overflow='hidden'
           my={{ base: '20px', md: '40px' }}
-          mx={{ base: '0px', sm: '20px', md: '40px' }}
+          mx={{ base: '0px', sm: '20px' }}
         >
           <Image
             fit={'cover'}
@@ -62,14 +60,13 @@ export const NFTDetail = () => {
         </Center>
         <VStack>
           <Text
-            ml={{ base: '10vw', sm: '0px', md: '20px' }}
-            mt={{ base: '10px', sm: '20px', md: '40px' }}
-            fontSize={{ base: 'xl', sm: '2xl', md: '4xl' }}
+            mx={{ base: '0px', md: '20px' }}
+            mt={{ base: '20px', md: '40px' }}
+            fontSize={{ base: '2xl', md: '3xl' }}
             fontWeight='bold'
           >
             Generave Art NFT #{index}
           </Text>
-          <Spacer />
         </VStack>
       </Stack>
     </>

--- a/src/NFTBarter_assets/src/Components/NFTDetail.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTDetail.tsx
@@ -1,10 +1,27 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { Center } from '@chakra-ui/react';
+import { decodeTokenId } from '../utils/ext';
+import { NotFound } from './NotFound';
+
+const CANISTER_ID =
+  process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
+    ? 'REPLACE_TO_CANISTER_ID'
+    : process.env.LOCAL_NFT_CANISTER_ID;
 
 export const NFTDetail = () => {
   const params = useParams();
   const tokenId = params.tokenId;
+  if (!tokenId) {
+    return <NotFound />;
+  }
+
+  const { canisterId } = decodeTokenId(tokenId);
+
+  // So far we only accept GenerativeArtNFT canister
+  if (canisterId !== CANISTER_ID) {
+    return <NotFound />;
+  }
 
   return <Center h='80vh'>{tokenId}</Center>;
 };

--- a/src/NFTBarter_assets/src/Components/NFTDetail.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTDetail.tsx
@@ -1,9 +1,31 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { Center } from '@chakra-ui/react';
+import {
+  Box,
+  Image,
+  HStack,
+  VStack,
+  Text,
+  Center,
+  Spacer,
+  useBreakpointValue,
+} from '@chakra-ui/react';
 import { decodeTokenId } from '../utils/ext';
+import {
+  GENERATIVE_ART_NFT_CANISTER_ID,
+  GENERATIVE_ART_NFT_BASE_URL as baseUrl,
+} from '../utils/canisterId';
 import { NotFound } from './NotFound';
-import { GENERATIVE_ART_NFT_CANISTER_ID } from '../utils/canisterId';
+import { UserIcon } from './UserIcon';
+
+const getStack = () => {
+  const isMobile = useBreakpointValue({ base: true, sm: false });
+  if (isMobile) {
+    return VStack;
+  } else {
+    return HStack;
+  }
+};
 
 export const NFTDetail = () => {
   const params = useParams();
@@ -12,12 +34,44 @@ export const NFTDetail = () => {
     return <NotFound />;
   }
 
-  const { canisterId } = decodeTokenId(tokenId);
+  const { index, canisterId } = decodeTokenId(tokenId);
 
   // So far we only accept GenerativeArtNFT canister
   if (canisterId !== GENERATIVE_ART_NFT_CANISTER_ID) {
     return <NotFound />;
   }
 
-  return <Center h='80vh'>{tokenId}</Center>;
+  const Stack = getStack();
+
+  return (
+    <>
+      <Stack maxW='1300px' mx='auto' alignItems='flex-start'>
+        <Center
+          width={{ base: '100%', sm: '40%' }}
+          borderRadius='lg'
+          overflow='hidden'
+          my={{ base: '20px', md: '40px' }}
+          mx={{ base: '0px', sm: '20px', md: '40px' }}
+        >
+          <Image
+            fit={'cover'}
+            maxHeight='70vw'
+            alt={`${tokenId}`}
+            src={`${baseUrl}/?tokenid=${tokenId}`}
+          />
+        </Center>
+        <VStack>
+          <Text
+            ml={{ base: '10vw', sm: '0px', md: '20px' }}
+            mt={{ base: '10px', sm: '20px', md: '40px' }}
+            fontSize={{ base: 'xl', sm: '2xl', md: '4xl' }}
+            fontWeight='bold'
+          >
+            Generave Art NFT #{index}
+          </Text>
+          <Spacer />
+        </VStack>
+      </Stack>
+    </>
+  );
 };

--- a/src/NFTBarter_assets/src/Components/NFTDetail.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTDetail.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   Box,
@@ -15,6 +15,9 @@ import {
   GENERATIVE_ART_NFT_CANISTER_ID,
   GENERATIVE_ART_NFT_BASE_URL as baseUrl,
 } from '../utils/canisterId';
+import { createActor } from '../../../declarations/GenerativeArtNFT';
+import { generateTokenIdentifier } from '../utils/ext';
+
 import { NotFound } from './NotFound';
 import { UserIcon } from './UserIcon';
 
@@ -28,6 +31,7 @@ const getStack = () => {
 };
 
 export const NFTDetail = () => {
+  const [accountId, setAccountId] = useState('');
   const Stack = getStack();
   const { tokenId } = useParams();
   const { index, canisterId } = decodeTokenId(tokenId);
@@ -36,6 +40,20 @@ export const NFTDetail = () => {
   if (canisterId && canisterId !== GENERATIVE_ART_NFT_CANISTER_ID) {
     return <NotFound />;
   }
+
+  const fetchBearer = async () => {
+    const actor = createActor(canisterId);
+    const tid = generateTokenIdentifier(canisterId, index);
+    const res = await actor.bearer(tid);
+    if ('ok' in res) {
+      const aid = res.ok;
+      setAccountId(aid);
+    }
+  };
+
+  useEffect(() => {
+    fetchBearer();
+  }, []);
 
   return (
     <>
@@ -58,15 +76,28 @@ export const NFTDetail = () => {
             src={`${baseUrl}/?tokenid=${tokenId}`}
           />
         </Center>
-        <VStack>
+        <VStack
+          alignItems={{ base: 'center', sm: 'flex-start' }}
+          mx={{ base: '0px', md: '20px' }}
+          spacing={{ base: '10px', md: '20px' }}
+        >
           <Text
-            mx={{ base: '0px', md: '20px' }}
             mt={{ base: '20px', md: '40px' }}
             fontSize={{ base: '2xl', md: '3xl' }}
             fontWeight='bold'
           >
             Generave Art NFT #{index}
           </Text>
+          <Spacer />
+          <HStack
+            fontSize={{ base: 'lg', md: 'xl' }}
+            alignItems='stretch'
+            spacing='12px'
+          >
+            <Text color='gray.400'>Owned by</Text>
+            <UserIcon diameter={28} accountId={accountId} />
+            <Text color='blue.400'>{accountId.slice(0, 8)}...</Text>
+          </HStack>
         </VStack>
       </Stack>
     </>

--- a/src/NFTBarter_assets/src/Components/Profile.tsx
+++ b/src/NFTBarter_assets/src/Components/Profile.tsx
@@ -1,11 +1,11 @@
 import React, { FC } from 'react';
 import { Center, Box, HStack, Image, Text } from '@chakra-ui/react';
 import { useAppSelector } from '../app/hooks';
-import { selectPrincipal } from '../features/auth/authSlice';
+import { selectAccountId } from '../features/auth/authSlice';
 import { UserIcon } from './UserIcon';
 import { MyGenerativeArtNFTs } from '../features/myGenerativeArtNFT/MyGenerativeArtNFTs';
 
-const PrincipalID: FC<{ principal: string }> = ({ principal }) => {
+const AccountID: FC<{ accountId: string }> = ({ accountId }) => {
   return (
     <Box
       rounded='full'
@@ -28,7 +28,7 @@ const PrincipalID: FC<{ principal: string }> = ({ principal }) => {
           w='32'
           fontSize='xs'
         >
-          {principal}
+          {accountId}
         </Text>
       </HStack>
     </Box>
@@ -36,16 +36,16 @@ const PrincipalID: FC<{ principal: string }> = ({ principal }) => {
 };
 
 export const Profile = () => {
-  const principal = useAppSelector(selectPrincipal);
+  const accountId = useAppSelector(selectAccountId);
 
   return (
     <>
       <Box h={{ base: '32', sm: '40' }} bg='#EDF4FF' />
       <Center pos='relative'>
         <Box pos='absolute' top='-50'>
-          <UserIcon diameter={100} />
+          <UserIcon diameter={100} accountId={accountId} />
         </Box>
-        <Box mt='20'>{principal && <PrincipalID principal={principal} />}</Box>
+        <Box mt='20'>{accountId && <AccountID accountId={accountId} />}</Box>
       </Center>
       <MyGenerativeArtNFTs />
       <Center h='60vh'></Center>

--- a/src/NFTBarter_assets/src/Components/UserIcon.tsx
+++ b/src/NFTBarter_assets/src/Components/UserIcon.tsx
@@ -1,33 +1,26 @@
 import React, { FC, useEffect, useRef } from 'react';
-import { Principal } from '@dfinity/principal';
 import Jazzicon from '@metamask/jazzicon';
 import { Box } from '@chakra-ui/react';
 
-import { useAppSelector } from '../app/hooks';
-import { selectPrincipal } from '../features/auth/authSlice';
-
 interface Props {
   diameter: number;
+  accountId: string | undefined;
 }
 
-export const UserIcon: FC<Props> = ({ diameter }) => {
+export const UserIcon: FC<Props> = ({ diameter, accountId }) => {
   const ref = useRef<HTMLDivElement | null>(null);
-  const principal = useAppSelector(selectPrincipal);
 
   useEffect(() => {
-    if (principal && ref.current) {
+    if (accountId && ref.current) {
       ref.current.innerHTML = '';
 
       // Since `number` in JavaScript is expressed as 64 bit (0x7FFFFFFFFFFFFFFF in hex),
       // it is safe and large enough to use the 10 chars in principal ID.
       ref.current.appendChild(
-        Jazzicon(
-          diameter,
-          parseInt(Principal.fromText(principal).toHex().slice(0, 10), 16)
-        )
+        Jazzicon(diameter, parseInt(accountId.slice(0, 10), 16))
       );
     }
-  }, [principal]);
+  }, [accountId]);
 
   return <Box ref={ref} />;
 };

--- a/src/NFTBarter_assets/src/features/mint/mintSlice.ts
+++ b/src/NFTBarter_assets/src/features/mint/mintSlice.ts
@@ -2,17 +2,13 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { AuthClient } from '@dfinity/auth-client';
 import { RootState, AsyncThunkConfig } from '../../app/store';
 import { generateTokenIdentifier } from '../../utils/ext';
+import { GENERATIVE_ART_NFT_CANISTER_ID as canisterId } from '../../utils/canisterId';
 
 import {
   User,
   MintRequest,
 } from '../../../../declarations/GenerativeArtNFT/GenerativeArtNFT.did.js';
 import { createActor } from '../../../../declarations/GenerativeArtNFT';
-
-const canisterId =
-  process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
-    ? 'REPLACE_TO_CANISTER_ID'
-    : process.env.LOCAL_NFT_CANISTER_ID;
 
 export interface MintState {
   tokenId?: string;

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { Box, SimpleGrid, Center } from '@chakra-ui/react';
 
 import { GENERATIVE_ART_NFT_BASE_URL as baseUrl } from '../../utils/canisterId';
@@ -20,13 +21,14 @@ export const MyGenerativeArtNFTs = () => {
         {nfts.map((nft) => {
           const { tokenId, tokenIndex } = nft;
           return (
-            <Center my='10px'>
-              <NFTCard
-                key={tokenIndex}
-                tokenId={tokenId}
-                tokenIndex={tokenIndex}
-                baseUrl={baseUrl}
-              />
+            <Center my='10px' key={tokenIndex}>
+              <Link to={`/asset/${tokenId}`}>
+                <NFTCard
+                  tokenId={tokenId}
+                  tokenIndex={tokenIndex}
+                  baseUrl={baseUrl}
+                />
+              </Link>
             </Center>
           );
         })}

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
@@ -1,13 +1,8 @@
 import React, { useEffect } from 'react';
 import { Box, SimpleGrid, Center } from '@chakra-ui/react';
 
+import { GENERATIVE_ART_NFT_BASE_URL as baseUrl } from '../../utils/canisterId';
 import { NFTCard } from './../../Components/NFTCard';
-
-const baseUrl =
-  process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
-    ? 'http://REPLACE_TO_CANISTER_ID.ic0.app'
-    : `http://${process.env.LOCAL_NFT_CANISTER_ID}.localhost:8000`;
-
 import { useAppSelector, useAppDispatch } from '../../app/hooks';
 import { fetchNFTs, selectNfts } from './myGenerativeArtNFTSlice';
 

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/myGenerativeArtNFTSlice.ts
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/myGenerativeArtNFTSlice.ts
@@ -2,14 +2,10 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { AuthClient } from '@dfinity/auth-client';
 import { RootState, AsyncThunkConfig } from '../../app/store';
 import { generateTokenIdentifier } from '../../utils/ext';
+import { GENERATIVE_ART_NFT_CANISTER_ID as canisterId } from '../../utils/canisterId';
 
 import { User } from '../../../../declarations/GenerativeArtNFT/GenerativeArtNFT.did.js';
 import { createActor } from '../../../../declarations/GenerativeArtNFT';
-
-const canisterId =
-  process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
-    ? 'REPLACE_TO_CANISTER_ID'
-    : process.env.LOCAL_NFT_CANISTER_ID;
 
 export interface GenerativeArtNFT {
   tokenId: string;

--- a/src/NFTBarter_assets/src/utils/canisterId.ts
+++ b/src/NFTBarter_assets/src/utils/canisterId.ts
@@ -2,3 +2,8 @@ export const GENERATIVE_ART_NFT_CANISTER_ID =
   process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
     ? 'REPLACE_TO_CANISTER_ID'
     : process.env.LOCAL_NFT_CANISTER_ID;
+
+export const GENERATIVE_ART_NFT_BASE_URL =
+  process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
+    ? 'http://REPLACE_TO_CANISTER_ID.ic0.app'
+    : `http://${process.env.LOCAL_NFT_CANISTER_ID}.localhost:8000`;

--- a/src/NFTBarter_assets/src/utils/canisterId.ts
+++ b/src/NFTBarter_assets/src/utils/canisterId.ts
@@ -1,0 +1,4 @@
+export const GENERATIVE_ART_NFT_CANISTER_ID =
+  process.env.DFX_NETWORK === 'ic' || !process.env.LOCAL_NFT_CANISTER_ID
+    ? 'REPLACE_TO_CANISTER_ID'
+    : process.env.LOCAL_NFT_CANISTER_ID;

--- a/src/NFTBarter_assets/src/utils/ext.test.ts
+++ b/src/NFTBarter_assets/src/utils/ext.test.ts
@@ -1,0 +1,37 @@
+import { generateTokenIdentifier, getSubAccount, decodeTokenId } from './ext';
+
+describe('generateTokenIdentifier test', () => {
+  it('Generate TokenIdentifier from canisterId and tokenIndex', async () => {
+    const canisterId = 'rrkah-fqaaa-aaaaa-aaaaq-cai';
+    const tokenIndex = 0;
+    const tokenIdentifier = 'dyi3c-bqkor-uwiaa-aaaaa-aaaaa-eaqca-aaaaa-a';
+    expect(generateTokenIdentifier(canisterId, tokenIndex)).toBe(
+      tokenIdentifier
+    );
+  });
+});
+
+describe('getSubAccount test', () => {
+  it('Generate SubAccount from passed index', async () => {
+    const accountIndex = 257;
+    const result = getSubAccount(accountIndex);
+    const expected = [
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1,
+    ]; // [u8; 32]
+    expect(result.length).toBe(32);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('decodeTokenId test', () => {
+  it('Decode TokenIdentifier to canisterId and tokenIndex', async () => {
+    const canisterId = 'rrkah-fqaaa-aaaaa-aaaaq-cai';
+    const index = 0;
+    const tokenIdentifier = 'dyi3c-bqkor-uwiaa-aaaaa-aaaaa-eaqca-aaaaa-a';
+    expect(decodeTokenId(tokenIdentifier)).toStrictEqual({
+      index,
+      canisterId,
+    });
+  });
+});

--- a/src/NFTBarter_assets/src/utils/ext.ts
+++ b/src/NFTBarter_assets/src/utils/ext.ts
@@ -23,9 +23,9 @@ export const getSubAccount = (index: number): number[] => {
   return Array(28).fill(0).concat(numberTo32bits(index));
 };
 
-export const decodeTokenId = (tid: string): TokenProps => {
-  if (!checkIfTextIsPrincipal(tid)) {
-    return { index: 0, canisterId: tid };
+export const decodeTokenId = (tid: string | undefined): TokenProps => {
+  if (!tid || !checkIfTextIsPrincipal(tid)) {
+    return { index: 0, canisterId: '' };
   }
 
   const array = [...Principal.fromText(tid).toUint8Array()];

--- a/src/NFTBarter_assets/src/utils/ext.ts
+++ b/src/NFTBarter_assets/src/utils/ext.ts
@@ -1,7 +1,7 @@
 import { toHexString } from '@dfinity/candid/lib/cjs/utils/buffer';
 import { Principal } from '@dfinity/principal';
-import { sha224 } from '@dfinity/principal/lib/esm/utils/sha224';
-import { getCrc32 } from '@dfinity/principal/lib/esm/utils/getCrc';
+import { sha224 } from '@dfinity/principal/lib/cjs/utils/sha224';
+import { getCrc32 } from '@dfinity/principal/lib/cjs/utils/getCrc';
 
 export type TokenProps = {
   index: number;

--- a/src/NFTBarter_assets/src/utils/ext.ts
+++ b/src/NFTBarter_assets/src/utils/ext.ts
@@ -1,5 +1,7 @@
 import { toHexString } from '@dfinity/candid/lib/cjs/utils/buffer';
 import { Principal } from '@dfinity/principal';
+import { sha224 } from '@dfinity/principal/lib/esm/utils/sha224';
+import { getCrc32 } from '@dfinity/principal/lib/esm/utils/getCrc';
 
 export type TokenProps = {
   index: number;
@@ -17,6 +19,21 @@ export const generateTokenIdentifier = (
     ...numberTo32bits(index),
   ]);
   return Principal.fromUint8Array(array).toText();
+};
+
+export const principalToAccountIdentifier = (
+  principal: string,
+  subAccount: number
+) => {
+  const padding = Buffer.from('\x0Aaccount-id');
+  const array = new Uint8Array([
+    ...padding,
+    ...Principal.fromText(principal).toUint8Array(),
+    ...getSubAccount(subAccount),
+  ]);
+  const hash = sha224(array);
+  const checksum = numberTo32bits(getCrc32(hash));
+  return toHexString(new Uint8Array([...checksum, ...hash]));
 };
 
 export const getSubAccount = (index: number): number[] => {

--- a/src/NFTBarter_assets/src/utils/ext.ts
+++ b/src/NFTBarter_assets/src/utils/ext.ts
@@ -24,6 +24,10 @@ export const getSubAccount = (index: number): number[] => {
 };
 
 export const decodeTokenId = (tid: string): TokenProps => {
+  if (!checkIfTextIsPrincipal(tid)) {
+    return { index: 0, canisterId: tid };
+  }
+
   const array = [...Principal.fromText(tid).toUint8Array()];
   const padding = new Uint8Array(array.splice(0, 4));
   if (toHexString(padding) !== toHexString(Buffer.from('\x0Atid'))) {
@@ -32,6 +36,15 @@ export const decodeTokenId = (tid: string): TokenProps => {
     const index = numberFrom32bits(array.splice(-4));
     const canisterId = Principal.fromUint8Array(new Uint8Array(array)).toText();
     return { index, canisterId };
+  }
+};
+
+const checkIfTextIsPrincipal = (text: string): boolean => {
+  try {
+    Principal.fromText(text);
+    return true;
+  } catch (e) {
+    return false;
   }
 };
 


### PR DESCRIPTION
# 概要・目的
NFT の詳細ページの作成
<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
Fixes #61 

# 変更内容
## やったこと
- asset/:tokenIdへのルーティングを設定 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/65c81a72aa08233990b22c2964a4a33c2d6e6ae3
- tokenIdからcanisterIdとindexをデコードする関数 `decodeTokenId` を追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/a1e0962c2a9c56f7313bcdaf43a9236d4441a452
- `decodeTokenId` のテストを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/89221661cc9b6c75b46d38162650d08ddd2fd948
- GenerativeArtNFT の CanisterID を取得するロジックを一元管理化 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/3f2014219d1d4d8afe3eed7de7db127af58aa06a
- NFT 詳細ページに NFT画像とNFT名を表示 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/e5386853d510ce7c889b954c59ff5cdc193a0ab0
- レスポンシブ表示の改善 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/aa8204f0b4d2eb87f306dc44d26df1fc9c965419
- ログインユーザーの accountId を feature/auth で管理するステートに追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/11a46a715c4f17f5d704e9df873d34e89c570ac9
- ユーザーアイコンの生成seedを、従来のprincipalからaccountIdに変更 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/0900c653ccbc48835c72679f6df4ed0fbbad97e9
- NFT詳細ページにNFTのオーナーを表示 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/bf0721a13a185c95d15a5aead68b19b58fd643e5
- プロフィールページのNFT一覧から各NFTの詳細ページへのリンクを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/4cb9f37e7e0a496cc18e87b303a90875be1a81a7
- jestでエラーが発生したため、esm読み込みをcjs読み込みに変更 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/0987753ec9c2faf427ce27d4f9cf28991e6a8cef
- invalidなtokenIdが指定された場合の処理におけるバグを修正 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/79d3335e0cb134e420bbfccb326d5eb04ffc83e1
<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
- ext.ts の `principalToAccountIdentifier` のテスト
- NFTを交換に出している場合とそうでない場合の表示切り替え
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
フロントエンド
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
プロフィール画面から各NFTのカードをクリックすると、以下のような詳細ページに遷移する
![image](https://user-images.githubusercontent.com/40290137/171425455-780223e6-613a-4c02-9167-71b51811c774.png)

<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足
EXTのbearerメソッドはAccountIdを返し、AccountIdからprincipalを復元するのは困難[[参考]](https://forum.dfinity.org/t/accountid-to-principal/7564/6?u=hoosan)であることから、（これまでユーザーアイコンのseedとしていた）principalからaccountIdに変更しました。
<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
