### PR TITLE
Add Nft Import Method & Exhibit Method

### DIFF
--- a/src/NFTBarter/ChildCanister.mo
+++ b/src/NFTBarter/ChildCanister.mo
@@ -10,7 +10,7 @@ import Principal "mo:base/Principal";
 import Blob "mo:base/Blob";
 import Iter "mo:base/Iter";
 
-shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal) = this {
+shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal, _canisterIdList : Types.CanisterIdList) = this {
   /* Local Types */
   type Error = Types.Error;
   type Result<T, E> = Result.Result<T, E>;
@@ -65,7 +65,7 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
 
       case (#MyExtStandartNft(token)) 
         switch (
-          await (actor("r7inp-6aaaa-aaaaa-aaabq-cai"): MyExtStandartNftCanisterIF)
+          await (actor(_canisterIdList.myExtStandartNft): MyExtStandartNftCanisterIF)
             .transfer({
               from = #principal(Principal.fromActor(this));
               to = #principal(Principal.fromActor(this));

--- a/src/NFTBarter/ChildCanister.mo
+++ b/src/NFTBarter/ChildCanister.mo
@@ -1,4 +1,143 @@
+//Local
+import Types "./Types";
 
-shared (install) actor class ChildCanister(_canisterOwner : Principal) = this {
-  
+// Motoko base
+import HashMap "mo:base/HashMap";
+import Hash "mo:base/Hash";
+import Nat "mo:base/Nat";
+import Result "mo:base/Result";
+import Principal "mo:base/Principal";
+import Blob "mo:base/Blob";
+import Iter "mo:base/Iter";
+
+shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal) = this {
+  /* Local Types */
+  type Error = Types.Error;
+  type Result<T, E> = Result.Result<T, E>;
+
+  type UserId = Types.UserId;
+  type CanisterID = Types.CanisterID;
+  type NftStatus = Types.NftStatus;
+  type Nft = Types.Nft;
+  // type NftImportRequest = Types.NftImportRequest;
+
+  /* Nfts Types */
+  // Sample Nft
+  // My Ext-Standart Nft
+  // type MyExtStandartNft = Types.MyExtStandartNft;
+  type MyExtStandartNftCanisterIF = Types.MyExtStandartNftCanisterIF;
+
+  /* Variables */
+  // this canister is never upgraded
+  stable var tokenIndex : Nat = 0;
+  let _assets = HashMap.HashMap<Nat, NftStatus>(
+    0, Nat.equal, Hash.hash
+  );
+  let _assetOwners = HashMap.HashMap<Nat, UserId>(
+    0, Nat.equal, Hash.hash
+  );
+  let _auctions = HashMap.HashMap<Nat, HashMap.HashMap<UserId, Nat>>(
+    0, Nat.equal, Hash.hash
+  );
+
+  /* Exhibit Methods */
+  public shared ({caller}) func importMyNft(nft : Nft) : async Result<Nat, Error> {
+    // Check Auth
+    if (Principal.isAnonymous(caller) or (caller != _canisterOwner)) 
+      { return #err(#unauthorized(Principal.toText(caller))) };
+    
+    // Check Double Import
+    if(
+      Iter.filter<(Nat, NftStatus)>(
+        _assets.entries(), func(index, nftStatus) {
+          let _nft = switch (nftStatus) {
+            case (#Stay(v)) v;
+            case (#Bid(v)) v;
+            case (#Exhibit(v)) v;
+          };
+          nft==_nft
+        }
+      ).next() != null
+    ) return #err(#alreadyRegistered(""));
+    
+    // Import Nft
+    switch (nft) {
+
+      case (#MyExtStandartNft(token)) 
+        switch (
+          await (actor("r7inp-6aaaa-aaaaa-aaabq-cai"): MyExtStandartNftCanisterIF)
+            .transfer({
+              from = #principal(Principal.fromActor(this));
+              to = #principal(Principal.fromActor(this));
+              token = token;
+              amount = 1;
+              memo = Blob.fromArray([]:[Nat8]);
+              notify = false;
+              subaccount = null;
+            })
+        ) {
+          case (#err(_)) return #err(#other("err"));
+          case (#ok(_)) {
+            tokenIndex += 1;
+            _assets.put(tokenIndex, #Stay(#MyExtStandartNft(token)));
+            _assetOwners.put(tokenIndex, _canisterOwner);
+          };
+        };
+      // new nft is added here
+    };
+    return #ok tokenIndex;
+  };
+
+  public shared ({caller}) func exhibitMyNft(token : Nat) : async Result<(), Error> {
+    // Check Auth
+    if (Principal.isAnonymous(caller) or (caller != _canisterOwner)) 
+      { return #err(#unauthorized(Principal.toText(caller))) };
+    
+    // Check Owner
+    switch (_assetOwners.get(token)) {
+      case (null) return #err(#notYetRegistered(""));
+      case (?owner) {
+        if (owner != _canisterOwner) return #err(#unauthorized(""));
+      }
+    };
+
+    // Change Nft Status
+    switch (_assets.get(token)) {
+      case (null) assert(false);
+      case (?nftStatus) switch (nftStatus) {
+        case (#Stay(nft)) _assets.put(token, #Exhibit(nft));
+        case (_) return #err(#alreadyRegistered(""));
+      }
+    };
+
+    // Start Bater Auction
+    switch (_auctions.get(token)) {
+      case (?_) assert(false);
+      case (null) _auctions.put(token, 
+        HashMap.HashMap<UserId, Nat>(0, Principal.equal, Principal.hash)
+      )
+    };
+
+    return #ok;
+  };
+
+  /* Bid Methods */
+
+
+  /* Helper Methods */
+  public query func getAssets() : async [(Nat, NftStatus)] {
+    Iter.toArray(_assets.entries())
+  };
+  public query func getAssetOwners() : async [(Nat, UserId)] {
+    Iter.toArray(_assetOwners.entries())
+  };
+  public query func getAuctions() : async [(Nat, [(UserId, Nat)])] {
+    Iter.toArray(
+      Iter.map<(Nat, HashMap.HashMap<UserId, Nat>), (Nat, [(UserId, Nat)])>(
+        _auctions.entries(), func(nat, hashmap) {
+          (nat, Iter.toArray(hashmap.entries()))
+        }
+      )
+    )
+  };
 }

--- a/src/NFTBarter/NftTypes/ExtTypes.mo
+++ b/src/NFTBarter/NftTypes/ExtTypes.mo
@@ -1,0 +1,35 @@
+import Result "mo:base/Result";
+
+module {
+  public type AccountIdentifier = Text;
+  public type TokenIdentifier  = Text;
+  public type Balance = Nat;
+  public type Memo = Blob;
+  public type SubAccount = [Nat8];
+
+  public type User = {
+    #address : AccountIdentifier; //No notification
+    #principal : Principal; //defaults to sub account 0
+  };
+
+  public type TransferRequest = {
+    from : User;
+    to : User;
+    token : TokenIdentifier;
+    amount : Balance;
+    memo : Memo;
+    notify : Bool;
+    subaccount : ?SubAccount;
+  };
+
+  public type TransferResponse = Result.Result<Balance, {
+    #Unauthorized: AccountIdentifier;
+    #InsufficientBalance;
+    #Rejected; //Rejected by canister
+    #InvalidToken: TokenIdentifier;
+    #CannotNotify: AccountIdentifier;
+    #Other : Text;
+  }>;
+
+
+}

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -34,6 +34,10 @@ module {
     // isBrother : CanisterID -> async Bool;
   };
 
+  public type CanisterIdList = {
+    myExtStandartNft : Text;
+  };
+
   // All Nft Type
   public type Nft = {
     // #SampleNft;

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -1,3 +1,15 @@
+// Motoko base
+// import HashMap "mo:base/HashMap";
+// import Hash "mo:base/Hash";
+// import Nat "mo:base/Nat";
+import Result "mo:base/Result";
+// import Principal "mo:base/Principal";
+
+
+// import Ext-Standart Types
+import ExtTypes "./NftTypes/ExtTypes";
+
+
 module {
 
   public type UserId = Principal;
@@ -12,6 +24,45 @@ module {
     #notYetRegistered : Text;
     #alreadyRegistered : Text;
     #other : Text;
+  };
+
+
+
+  /* For Child Canister */
+  // Parent Types
+  public type ParentIF = actor {
+    // isBrother : CanisterID -> async Bool;
+  };
+
+  // All Nft Type
+  public type Nft = {
+    // #SampleNft;
+    #MyExtStandartNft : ExtTypes.TokenIdentifier;
+  };
+  
+  public type NftStatus = {
+    #Stay : Nft;
+    #Bid : Nft;
+    #Exhibit : Nft
+  };
+
+  // Import Request
+  // public type NftImportRequest = {
+  //   // #SampleNft : {
+  //   //   canisterId : CanisterID;
+  //   // };
+  //   #MyExtStandartNft : {
+  //     canisterId : CanisterID;
+  //     token : ExtTypes.TokenIdentifier;
+  //   }
+  // };
+
+  /* Actor Interfaces */
+  // public type SampleNftCanisterIF = actor {
+  //   transfer : Principal -> async Result.Result<(), ()>;
+  // };
+  public type MyExtStandartNftCanisterIF = actor {
+    transfer : ExtTypes.TransferRequest -> async ExtTypes.TransferResponse;
   }
 
 }

--- a/src/NFTBarter/main.mo
+++ b/src/NFTBarter/main.mo
@@ -70,7 +70,7 @@ shared (install) actor class NFTBarter() = this {
 
   /* child canister functions */
   public shared ({ caller }) func mintChildCanister(): async Principal {
-    let child = await ChildCanister.ChildCanister(caller);
+    let child = await ChildCanister.ChildCanister(caller, {myExtStandartNft="r7inp-6aaaa-aaaaa-aaabq-cai"});
     _childCanisters.put(Principal.fromActor(child), caller);
     Principal.fromActor(child);
   };


### PR DESCRIPTION
# 概要・目的
ChildCanisterがNFTを取り込むためのメソッドを追加する
<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
Fixes #68 

# 変更内容
## やったこと

- NFT 型を定義
- Ext-Standardの型を定義
- ChildCanisterが保持するAssetを管理するHashMapの追加
- NFTをChildCanisterへ取り込む`importMyNft()`の追加
- NFTを出品状態にする`exhibitMyNft()`の追加

<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと

<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->
入札の処理と落札の処理
## 影響範囲
ChildCanister.mo 
Types.mo
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
transferが常にtrueを返すTextNft.moを一時的に作成しテストを行った．
重複してNFTを取り込まないことは確認済み．

<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足
テストはシェルスクリプトで目視で行っているので，自動化できればお願いしたいです．
<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
