### PR TITLE
Add frontend code for exhibiting NFT

### DIFF
--- a/src/NFTBarter/ChildCanister.mo
+++ b/src/NFTBarter/ChildCanister.mo
@@ -24,8 +24,8 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
   /* Nfts Types */
   // Sample Nft
   // My Ext-Standart Nft
-  // type myExtStandardNft = Types.myExtStandardNft;
-  type myExtStandardNftCanisterIF = Types.myExtStandardNftCanisterIF;
+  // type MyExtStandardNft = Types.MyExtStandardNft;
+  type MyExtStandardNftCanisterIF = Types.MyExtStandardNftCanisterIF;
 
   /* Variables */
   // this canister is never upgraded
@@ -63,9 +63,9 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
     // Import Nft
     switch (nft) {
 
-      case (#myExtStandardNft(token)) 
+      case (#MyExtStandardNft(token)) 
         switch (
-          await (actor(_canisterIdList.myExtStandardNft): myExtStandardNftCanisterIF)
+          await (actor(_canisterIdList.myExtStandardNft): MyExtStandardNftCanisterIF)
             .transfer({
               from = #principal(Principal.fromActor(this));
               to = #principal(Principal.fromActor(this));
@@ -79,7 +79,7 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
           case (#err(_)) return #err(#other("err"));
           case (#ok(_)) {
             tokenIndex += 1;
-            _assets.put(tokenIndex, #Stay(#myExtStandardNft(token)));
+            _assets.put(tokenIndex, #Stay(#MyExtStandardNft(token)));
             _assetOwners.put(tokenIndex, _canisterOwner);
           };
         };

--- a/src/NFTBarter/ChildCanister.mo
+++ b/src/NFTBarter/ChildCanister.mo
@@ -24,8 +24,8 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
   /* Nfts Types */
   // Sample Nft
   // My Ext-Standart Nft
-  // type MyExtStandartNft = Types.MyExtStandartNft;
-  type MyExtStandartNftCanisterIF = Types.MyExtStandartNftCanisterIF;
+  // type myExtStandardNft = Types.myExtStandardNft;
+  type myExtStandardNftCanisterIF = Types.myExtStandardNftCanisterIF;
 
   /* Variables */
   // this canister is never upgraded
@@ -63,9 +63,9 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
     // Import Nft
     switch (nft) {
 
-      case (#MyExtStandartNft(token)) 
+      case (#myExtStandardNft(token)) 
         switch (
-          await (actor(_canisterIdList.myExtStandartNft): MyExtStandartNftCanisterIF)
+          await (actor(_canisterIdList.myExtStandardNft): myExtStandardNftCanisterIF)
             .transfer({
               from = #principal(Principal.fromActor(this));
               to = #principal(Principal.fromActor(this));
@@ -79,7 +79,7 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
           case (#err(_)) return #err(#other("err"));
           case (#ok(_)) {
             tokenIndex += 1;
-            _assets.put(tokenIndex, #Stay(#MyExtStandartNft(token)));
+            _assets.put(tokenIndex, #Stay(#myExtStandardNft(token)));
             _assetOwners.put(tokenIndex, _canisterOwner);
           };
         };

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -41,7 +41,7 @@ module {
   // All Nft Type
   public type Nft = {
     // #SampleNft;
-    #myExtStandardNft : ExtTypes.TokenIdentifier;
+    #MyExtStandardNft : ExtTypes.TokenIdentifier;
   };
   
   public type NftStatus = {
@@ -55,7 +55,7 @@ module {
   //   // #SampleNft : {
   //   //   canisterId : CanisterID;
   //   // };
-  //   #myExtStandardNft : {
+  //   #MyExtStandardNft : {
   //     canisterId : CanisterID;
   //     token : ExtTypes.TokenIdentifier;
   //   }
@@ -65,7 +65,7 @@ module {
   // public type SampleNftCanisterIF = actor {
   //   transfer : Principal -> async Result.Result<(), ()>;
   // };
-  public type myExtStandardNftCanisterIF = actor {
+  public type MyExtStandardNftCanisterIF = actor {
     transfer : ExtTypes.TransferRequest -> async ExtTypes.TransferResponse;
   }
 

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -35,13 +35,13 @@ module {
   };
 
   public type CanisterIdList = {
-    myExtStandartNft : Text;
+    myExtStandardNft : Text;
   };
 
   // All Nft Type
   public type Nft = {
     // #SampleNft;
-    #MyExtStandartNft : ExtTypes.TokenIdentifier;
+    #myExtStandardNft : ExtTypes.TokenIdentifier;
   };
   
   public type NftStatus = {
@@ -55,7 +55,7 @@ module {
   //   // #SampleNft : {
   //   //   canisterId : CanisterID;
   //   // };
-  //   #MyExtStandartNft : {
+  //   #myExtStandardNft : {
   //     canisterId : CanisterID;
   //     token : ExtTypes.TokenIdentifier;
   //   }
@@ -65,7 +65,7 @@ module {
   // public type SampleNftCanisterIF = actor {
   //   transfer : Principal -> async Result.Result<(), ()>;
   // };
-  public type MyExtStandartNftCanisterIF = actor {
+  public type myExtStandardNftCanisterIF = actor {
     transfer : ExtTypes.TransferRequest -> async ExtTypes.TransferResponse;
   }
 

--- a/src/NFTBarter/main.mo
+++ b/src/NFTBarter/main.mo
@@ -69,11 +69,26 @@ shared (install) actor class NFTBarter() = this {
   };
 
   /* child canister functions */
-  public shared ({ caller }) func mintChildCanister(): async Principal {
+  public shared ({ caller }) func mintChildCanister(): async Result<CanisterID, Error> {
+    if (Principal.isAnonymous(caller)) { return #err(#unauthorized(Principal.toText(caller))) };
+
     let child = await ChildCanister.ChildCanister(caller, {myExtStandartNft="r7inp-6aaaa-aaaaa-aaabq-cai"});
     _childCanisters.put(Principal.fromActor(child), caller);
-    Principal.fromActor(child);
+    #ok (Principal.fromActor(child))
   };
+
+  // Returns array of canister ids of `caller`.
+  public query ({ caller }) func getMyChildCanisters(): async Result<[CanisterID], Error> {
+    if (Principal.isAnonymous(caller)) { return #err(#unauthorized(Principal.toText(caller))) };
+
+    let canisterIdsOfUser = Iter.filter<(CanisterID, UserId)>(_childCanisters.entries(), func (entry) {
+      entry.1 == caller
+    });
+    #ok (Iter.toArray(Iter.map<(CanisterID, UserId), CanisterID>(canisterIdsOfUser, func (entry) {
+      entry.0
+    })))
+  };
+
   /* system functions */
   // The work required before a canister upgrade begins.
   system func preupgrade() {

--- a/src/NFTBarter/main.mo
+++ b/src/NFTBarter/main.mo
@@ -72,7 +72,7 @@ shared (install) actor class NFTBarter() = this {
   public shared ({ caller }) func mintChildCanister(): async Result<CanisterID, Error> {
     if (Principal.isAnonymous(caller)) { return #err(#unauthorized(Principal.toText(caller))) };
 
-    let child = await ChildCanister.ChildCanister(caller, {myExtStandartNft="r7inp-6aaaa-aaaaa-aaabq-cai"});
+    let child = await ChildCanister.ChildCanister(caller, {myExtStandardNft="r7inp-6aaaa-aaaaa-aaabq-cai"});
     _childCanisters.put(Principal.fromActor(child), caller);
     #ok (Principal.fromActor(child))
   };

--- a/src/NFTBarter_assets/src/Components/NFTCard.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTCard.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { Link } from 'react-router-dom';
 import { Box, Image, Text, HStack, Spacer } from '@chakra-ui/react';
 
 import { ExhibitButton } from '../features/exhibit/ExhibitButton';
@@ -18,12 +19,14 @@ export const NFTCard: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
       borderWidth='1px'
       overflow='hidden'
     >
-      <Image
-        fit={'cover'}
-        width='100%'
-        alt={`${tokenId}`}
-        src={`${baseUrl}/?tokenid=${tokenId}`}
-      />
+      <Link to={`/asset/${tokenId}`}>
+        <Image
+          fit={'cover'}
+          width='100%'
+          alt={`${tokenId}`}
+          src={`${baseUrl}/?tokenid=${tokenId}`}
+        />
+      </Link>
       <HStack alignItems='center'>
         <Text
           p={{ base: 2, lg: 3 }}
@@ -31,7 +34,11 @@ export const NFTCard: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
         >{`# ${tokenIndex}`}</Text>
         <Spacer />
         <Box p='10px'>
-          <ExhibitButton />
+          <ExhibitButton
+            tokenId={tokenId}
+            tokenIndex={tokenIndex}
+            baseUrl={baseUrl}
+          />
         </Box>
       </HStack>
     </Box>

--- a/src/NFTBarter_assets/src/Components/NFTCard.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTCard.tsx
@@ -1,5 +1,7 @@
 import React, { FC } from 'react';
-import { Box, Image, Text } from '@chakra-ui/react';
+import { Box, Image, Text, HStack, Spacer } from '@chakra-ui/react';
+
+import { ExhibitButton } from '../features/exhibit/ExhibitButton';
 
 interface Props {
   tokenId: string;
@@ -9,17 +11,29 @@ interface Props {
 
 export const NFTCard: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
   return (
-    <Box width='200px' borderRadius='xl' borderWidth='1px' overflow='hidden'>
+    <Box
+      minWidth='150px'
+      maxWidth='200px'
+      borderRadius='xl'
+      borderWidth='1px'
+      overflow='hidden'
+    >
       <Image
         fit={'cover'}
         width='100%'
         alt={`${tokenId}`}
         src={`${baseUrl}/?tokenid=${tokenId}`}
       />
-      <Text
-        p={{ base: 2, lg: 3 }}
-        fontSize={{ base: 'xs', md: 'sm' }}
-      >{`# ${tokenIndex}`}</Text>
+      <HStack alignItems='center'>
+        <Text
+          p={{ base: 2, lg: 3 }}
+          fontSize={{ base: 'xs', md: 'sm' }}
+        >{`# ${tokenIndex}`}</Text>
+        <Spacer />
+        <Box p='10px'>
+          <ExhibitButton />
+        </Box>
+      </HStack>
     </Box>
   );
 };

--- a/src/NFTBarter_assets/src/Components/Profile.tsx
+++ b/src/NFTBarter_assets/src/Components/Profile.tsx
@@ -4,7 +4,6 @@ import { useAppSelector } from '../app/hooks';
 import { selectAccountId } from '../features/auth/authSlice';
 import { UserIcon } from './UserIcon';
 import { MyGenerativeArtNFTs } from '../features/myGenerativeArtNFT/MyGenerativeArtNFTs';
-import { selectError } from '../features/exhibit/exhibitSlice';
 
 const AccountID: FC<{ accountId: string }> = ({ accountId }) => {
   return (
@@ -38,7 +37,6 @@ const AccountID: FC<{ accountId: string }> = ({ accountId }) => {
 
 export const Profile = () => {
   const accountId = useAppSelector(selectAccountId);
-  const error = useAppSelector(selectError);
 
   return (
     <>
@@ -50,7 +48,6 @@ export const Profile = () => {
         <Box mt='20'>{accountId && <AccountID accountId={accountId} />}</Box>
       </Center>
       <MyGenerativeArtNFTs />
-      {error && <Text>{JSON.stringify(error)}</Text>}
       <Center h='60vh'></Center>
     </>
   );

--- a/src/NFTBarter_assets/src/Components/Profile.tsx
+++ b/src/NFTBarter_assets/src/Components/Profile.tsx
@@ -4,6 +4,7 @@ import { useAppSelector } from '../app/hooks';
 import { selectAccountId } from '../features/auth/authSlice';
 import { UserIcon } from './UserIcon';
 import { MyGenerativeArtNFTs } from '../features/myGenerativeArtNFT/MyGenerativeArtNFTs';
+import { selectError } from '../features/exhibit/exhibitSlice';
 
 const AccountID: FC<{ accountId: string }> = ({ accountId }) => {
   return (
@@ -37,6 +38,7 @@ const AccountID: FC<{ accountId: string }> = ({ accountId }) => {
 
 export const Profile = () => {
   const accountId = useAppSelector(selectAccountId);
+  const error = useAppSelector(selectError);
 
   return (
     <>
@@ -48,6 +50,7 @@ export const Profile = () => {
         <Box mt='20'>{accountId && <AccountID accountId={accountId} />}</Box>
       </Center>
       <MyGenerativeArtNFTs />
+      {error && <Text>{JSON.stringify(error)}</Text>}
       <Center h='60vh'></Center>
     </>
   );

--- a/src/NFTBarter_assets/src/app/store.ts
+++ b/src/NFTBarter_assets/src/app/store.ts
@@ -30,6 +30,6 @@ export type AppThunk<ReturnType = void> = ThunkAction<
 >;
 export type AsyncThunkConfig<T = unknown> = {
   state: RootState;
-  dispatch: Dispatch;
+  dispatch: AppDispatch;
   rejectValue: T;
 };

--- a/src/NFTBarter_assets/src/app/store.ts
+++ b/src/NFTBarter_assets/src/app/store.ts
@@ -1,11 +1,7 @@
-import {
-  configureStore,
-  ThunkAction,
-  Action,
-  Dispatch,
-} from '@reduxjs/toolkit';
+import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
 import authReducer from '../features/auth/authSlice';
 import mintReducer from '../features/mint/mintSlice';
+import tranferReducer from '../features/transfer/transferSlice';
 import myGenerativeArtNFTReducer from '../features/myGenerativeArtNFT/myGenerativeArtNFTSlice';
 import exhibitReducer from '../features/exhibit/exhibitSlice';
 import childCanisterReducer from '../features/childCanister/childCanisterSlice';
@@ -14,6 +10,7 @@ export const store = configureStore({
   reducer: {
     auth: authReducer,
     mint: mintReducer,
+    transfer: tranferReducer,
     myGenerativeArtNFT: myGenerativeArtNFTReducer,
     exhibit: exhibitReducer,
     childCanister: childCanisterReducer,

--- a/src/NFTBarter_assets/src/app/store.ts
+++ b/src/NFTBarter_assets/src/app/store.ts
@@ -7,12 +7,14 @@ import {
 import authReducer from '../features/auth/authSlice';
 import mintReducer from '../features/mint/mintSlice';
 import myGenerativeArtNFTReducer from '../features/myGenerativeArtNFT/myGenerativeArtNFTSlice';
+import exhibitReducer from '../features/exhibit/exhibitSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     mint: mintReducer,
     myGenerativeArtNFT: myGenerativeArtNFTReducer,
+    exhibit: exhibitReducer,
   },
 });
 

--- a/src/NFTBarter_assets/src/app/store.ts
+++ b/src/NFTBarter_assets/src/app/store.ts
@@ -8,6 +8,7 @@ import authReducer from '../features/auth/authSlice';
 import mintReducer from '../features/mint/mintSlice';
 import myGenerativeArtNFTReducer from '../features/myGenerativeArtNFT/myGenerativeArtNFTSlice';
 import exhibitReducer from '../features/exhibit/exhibitSlice';
+import childCanisterReducer from '../features/childCanister/childCanisterSlice';
 
 export const store = configureStore({
   reducer: {
@@ -15,6 +16,7 @@ export const store = configureStore({
     mint: mintReducer,
     myGenerativeArtNFT: myGenerativeArtNFTReducer,
     exhibit: exhibitReducer,
+    childCanister: childCanisterReducer,
   },
 });
 

--- a/src/NFTBarter_assets/src/features/childCanister/childCanisterSlice.ts
+++ b/src/NFTBarter_assets/src/features/childCanister/childCanisterSlice.ts
@@ -1,0 +1,47 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { AuthClient } from '@dfinity/auth-client';
+import { Identity } from '@dfinity/agent';
+
+import { RootState, AsyncThunkConfig } from '../../app/store';
+import { createNFTBarterActor } from '../../utils/createNFTBarterActor';
+import {
+  UserProfile,
+  Result,
+  Error,
+} from '../../../../declarations/NFTBarter/NFTBarter.did';
+
+export interface ChildCanisterState {
+  error?: Error;
+}
+
+const initialState: ChildCanisterState = {};
+
+export const create = createAsyncThunk<
+  ChildCanisterState,
+  undefined,
+  AsyncThunkConfig<{ error: Error }>
+>('childCanisterSlice/create', async (_, { rejectWithValue }) => {
+  const authClient = await AuthClient.create();
+
+  if (!authClient) {
+    throw new Error('Failed to use auth client.');
+  }
+
+  return rejectWithValue({ error: { other: '' } });
+});
+
+export const childCanisterSlice = createSlice({
+  name: 'childCanister',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(create.fulfilled, (state, action) => {});
+    builder.addCase(create.rejected, (state, action) => {
+      state.error = action.payload?.error;
+    });
+  },
+});
+
+export const selectError = (state: RootState) => state.childCanister.error;
+
+export default childCanisterSlice.reducer;

--- a/src/NFTBarter_assets/src/features/childCanister/childCanisterSlice.ts
+++ b/src/NFTBarter_assets/src/features/childCanister/childCanisterSlice.ts
@@ -1,33 +1,77 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { AuthClient } from '@dfinity/auth-client';
-import { Identity } from '@dfinity/agent';
+import { Principal } from '@dfinity/principal';
 
 import { RootState, AsyncThunkConfig } from '../../app/store';
 import { createNFTBarterActor } from '../../utils/createNFTBarterActor';
-import {
-  UserProfile,
-  Result,
-  Error,
-} from '../../../../declarations/NFTBarter/NFTBarter.did';
+import { Error } from '../../../../declarations/NFTBarter/NFTBarter.did';
 
 export interface ChildCanisterState {
+  canisterIds: Principal[];
   error?: Error;
 }
 
-const initialState: ChildCanisterState = {};
+const initialState: ChildCanisterState = {
+  canisterIds: [],
+};
 
-export const create = createAsyncThunk<
+export const getChildCanisters = createAsyncThunk<
   ChildCanisterState,
   undefined,
   AsyncThunkConfig<{ error: Error }>
->('childCanisterSlice/create', async (_, { rejectWithValue }) => {
+>('childCanister/get', async (_, { rejectWithValue }) => {
   const authClient = await AuthClient.create();
 
-  if (!authClient) {
-    throw new Error('Failed to use auth client.');
+  if (!authClient || !authClient.isAuthenticated()) {
+    return rejectWithValue({
+      error: { unauthorized: 'Failed to use auth client.' },
+    });
   }
 
-  return rejectWithValue({ error: { other: '' } });
+  const identity = await authClient.getIdentity();
+  const actor = createNFTBarterActor({
+    agentOptions: { identity },
+  });
+
+  const res = await actor.getMyChildCanisters();
+  if ('ok' in res) {
+    const canisterIds = res.ok;
+    return {
+      canisterIds,
+    };
+  } else {
+    return rejectWithValue({
+      error: res.err,
+    });
+  }
+});
+
+export const createChildCanister = createAsyncThunk<
+  ChildCanisterState,
+  undefined,
+  AsyncThunkConfig<{ error: Error }>
+>('childCanister/create', async (_, { rejectWithValue }) => {
+  const authClient = await AuthClient.create();
+
+  if (!authClient || !authClient.isAuthenticated()) {
+    return rejectWithValue({
+      error: { unauthorized: 'Failed to use auth client.' },
+    });
+  }
+
+  const identity = await authClient.getIdentity();
+  const actor = createNFTBarterActor({
+    agentOptions: { identity },
+  });
+
+  const res = await actor.mintChildCanister();
+  if ('ok' in res) {
+    return { canisterIds: [res.ok] };
+  } else {
+    return rejectWithValue({
+      error: res.err,
+    });
+  }
 });
 
 export const childCanisterSlice = createSlice({
@@ -35,13 +79,26 @@ export const childCanisterSlice = createSlice({
   initialState,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(create.fulfilled, (state, action) => {});
-    builder.addCase(create.rejected, (state, action) => {
+    builder.addCase(getChildCanisters.fulfilled, (state, action) => {
+      state.canisterIds = action.payload?.canisterIds;
+    });
+    builder.addCase(getChildCanisters.rejected, (state, action) => {
+      state.error = action.payload?.error;
+    });
+    builder.addCase(createChildCanister.fulfilled, (state, action) => {
+      state.canisterIds = [
+        ...state.canisterIds,
+        ...action.payload?.canisterIds,
+      ];
+    });
+    builder.addCase(createChildCanister.rejected, (state, action) => {
       state.error = action.payload?.error;
     });
   },
 });
 
+export const selectCanisterIds = (state: RootState) =>
+  state.childCanister.canisterIds;
 export const selectError = (state: RootState) => state.childCanister.error;
 
 export default childCanisterSlice.reducer;

--- a/src/NFTBarter_assets/src/features/childCanister/childCanisterSlice.ts
+++ b/src/NFTBarter_assets/src/features/childCanister/childCanisterSlice.ts
@@ -1,13 +1,12 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { AuthClient } from '@dfinity/auth-client';
-import { Principal } from '@dfinity/principal';
 
 import { RootState, AsyncThunkConfig } from '../../app/store';
 import { createNFTBarterActor } from '../../utils/createNFTBarterActor';
 import { Error } from '../../../../declarations/NFTBarter/NFTBarter.did';
 
 export interface ChildCanisterState {
-  canisterIds: Principal[];
+  canisterIds: string[];
   error?: Error;
 }
 
@@ -35,9 +34,8 @@ export const getChildCanisters = createAsyncThunk<
 
   const res = await actor.getMyChildCanisters();
   if ('ok' in res) {
-    const canisterIds = res.ok;
     return {
-      canisterIds,
+      canisterIds: res.ok.map((p) => p.toText()),
     };
   } else {
     return rejectWithValue({
@@ -66,7 +64,7 @@ export const createChildCanister = createAsyncThunk<
 
   const res = await actor.mintChildCanister();
   if ('ok' in res) {
-    return { canisterIds: [res.ok] };
+    return { canisterIds: [res.ok.toText()] };
   } else {
     return rejectWithValue({
       error: res.err,

--- a/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
+++ b/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
@@ -27,14 +27,14 @@ interface Props {
 export const ExhibitButton: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
   const dispatch = useAppDispatch();
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const childChildCanisterId = useAppSelector(selectChildCanisterId);
+  const childCanisterId = useAppSelector(selectChildCanisterId);
 
   const handleClickExhibitButton = () => {
     onOpen();
   };
 
   const handleClickYesButton = async () => {
-    await dispatch(exhibit());
+    await dispatch(exhibit({ tokenId }));
     onClose();
   };
 
@@ -60,7 +60,7 @@ export const ExhibitButton: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
               </Text>
               {/* Just for test purpose */}
               <Text fontSize='md' fontWeight='bold'>
-                {childChildCanisterId}
+                {childCanisterId}
               </Text>
             </VStack>
           </ModalBody>

--- a/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
+++ b/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
@@ -15,7 +15,8 @@ import {
   Box,
 } from '@chakra-ui/react';
 
-import { useAppDispatch } from '../../app/hooks';
+import { useAppDispatch, useAppSelector } from '../../app/hooks';
+import { exhibit, selectChildCanisterId } from './exhibitSlice';
 
 interface Props {
   tokenId: string;
@@ -26,9 +27,15 @@ interface Props {
 export const ExhibitButton: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
   const dispatch = useAppDispatch();
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const childChildCanisterId = useAppSelector(selectChildCanisterId);
 
   const handleClickExhibitButton = () => {
     onOpen();
+  };
+
+  const handleClickYesButton = async () => {
+    await dispatch(exhibit());
+    onClose();
   };
 
   return (
@@ -51,6 +58,10 @@ export const ExhibitButton: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
               <Text fontSize='md' fontWeight='bold'>
                 Do you wish to exhibit your NFT?
               </Text>
+              {/* Just for test purpose */}
+              <Text fontSize='md' fontWeight='bold'>
+                {childChildCanisterId}
+              </Text>
             </VStack>
           </ModalBody>
 
@@ -59,7 +70,7 @@ export const ExhibitButton: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
               color='white'
               bgGradient='linear(to-r, blue.300, green.200)'
               mr={3}
-              onClick={onClose}
+              onClick={handleClickYesButton}
             >
               YES
             </Button>

--- a/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
+++ b/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Button, Text } from '@chakra-ui/react';
+
+import { useAppDispatch } from '../../app/hooks';
+
+export const ExhibitButton = () => {
+  const dispatch = useAppDispatch();
+
+  return (
+    <Button
+      color='white'
+      px='1em'
+      fontSize={{ base: 'sm', md: 'md' }}
+      height='2em'
+      bgGradient='linear(to-r, blue.300, green.200)'
+      borderRadius='xl'
+      _hover={{ bgGradient: 'linear(to-r, blue.400, green.300)' }}
+      onClick={async () => {}}
+    >
+      <Text fontWeight='semibold'>Exhibit</Text>
+    </Button>
+  );
+};

--- a/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
+++ b/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
@@ -16,7 +16,7 @@ import {
 } from '@chakra-ui/react';
 
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
-import { exhibit, selectChildCanisterId } from './exhibitSlice';
+import { exhibit, selectChildCanisterId, selectError } from './exhibitSlice';
 
 interface Props {
   tokenId: string;
@@ -28,6 +28,7 @@ export const ExhibitButton: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
   const dispatch = useAppDispatch();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const childCanisterId = useAppSelector(selectChildCanisterId);
+  const error = useAppSelector(selectError);
 
   const handleClickExhibitButton = () => {
     onOpen();
@@ -35,7 +36,7 @@ export const ExhibitButton: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
 
   const handleClickYesButton = async () => {
     await dispatch(exhibit({ tokenId }));
-    onClose();
+    // onClose();
   };
 
   return (
@@ -62,6 +63,7 @@ export const ExhibitButton: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
               <Text fontSize='md' fontWeight='bold'>
                 {childCanisterId}
               </Text>
+              {error && <Text>{error}</Text>}
             </VStack>
           </ModalBody>
 

--- a/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
+++ b/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
@@ -1,23 +1,88 @@
-import React from 'react';
-import { Button, Text } from '@chakra-ui/react';
+import React, { FC } from 'react';
+import {
+  ModalHeader,
+  ModalBody,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  Image,
+  Spacer,
+  VStack,
+  ModalFooter,
+  useDisclosure,
+  Button,
+  Text,
+  Box,
+} from '@chakra-ui/react';
 
 import { useAppDispatch } from '../../app/hooks';
 
-export const ExhibitButton = () => {
+interface Props {
+  tokenId: string;
+  tokenIndex: number;
+  baseUrl: string;
+}
+
+export const ExhibitButton: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
   const dispatch = useAppDispatch();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const handleClickExhibitButton = () => {
+    onOpen();
+  };
 
   return (
-    <Button
-      color='white'
-      px='1em'
-      fontSize={{ base: 'sm', md: 'md' }}
-      height='2em'
-      bgGradient='linear(to-r, blue.300, green.200)'
-      borderRadius='xl'
-      _hover={{ bgGradient: 'linear(to-r, blue.400, green.300)' }}
-      onClick={async () => {}}
-    >
-      <Text fontWeight='semibold'>Exhibit</Text>
-    </Button>
+    <>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent mx='4px'>
+          <ModalHeader mx='auto'>Confirmation</ModalHeader>
+          <ModalBody>
+            <VStack>
+              <Text fontSize='md'># {tokenIndex}</Text>
+              <Box minWidth='150px' maxWidth='200px'>
+                <Image
+                  fit={'cover'}
+                  width='100%'
+                  alt={`${tokenId}`}
+                  src={`${baseUrl}/?tokenid=${tokenId}`}
+                />
+              </Box>
+              <Text fontSize='md' fontWeight='bold'>
+                Do you wish to exhibit your NFT?
+              </Text>
+            </VStack>
+          </ModalBody>
+
+          <ModalFooter justifyContent='center'>
+            <Button
+              color='white'
+              bgGradient='linear(to-r, blue.300, green.200)'
+              mr={3}
+              onClick={onClose}
+            >
+              YES
+            </Button>
+            <Spacer />
+            <Button onClick={onClose} color='white' bgColor='gray.300'>
+              NO
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <Button
+        color='white'
+        px='1em'
+        fontSize={{ base: 'sm', md: 'md' }}
+        height='2em'
+        bgGradient='linear(to-r, blue.300, green.200)'
+        borderRadius='xl'
+        _hover={{ bgGradient: 'linear(to-r, blue.400, green.300)' }}
+        onClick={handleClickExhibitButton}
+      >
+        <Text fontWeight='semibold'>Exhibit</Text>
+      </Button>
+    </>
   );
 };

--- a/src/NFTBarter_assets/src/features/exhibit/exhibitSlice.ts
+++ b/src/NFTBarter_assets/src/features/exhibit/exhibitSlice.ts
@@ -77,13 +77,14 @@ export const exhibit = createAsyncThunk<
     });
   }
 
+  const actor = createChildCanisterActorByCanisterId(childCanisterId)({
+    agentOptions: { identity },
+  });
+  const nft: Nft = { myExtStandardNft: tokenId };
+
   // Import NFT into child canister
   let tokenIndexOnChildCanister: bigint;
   try {
-    const actor = createChildCanisterActorByCanisterId(childCanisterId)({
-      agentOptions: { identity },
-    });
-    const nft: Nft = { myExtStandardNft: tokenId };
     const res = await actor.importMyNft(nft);
     if ('ok' in res) {
       tokenIndexOnChildCanister = res.ok;
@@ -96,6 +97,24 @@ export const exhibit = createAsyncThunk<
     return rejectWithValue({
       error: {
         other: 'Error occured during importing NFT to child canisters.',
+      },
+    });
+  }
+
+  // Exhibit NFT
+  try {
+    const res = await actor.exhibitMyNft(tokenIndexOnChildCanister);
+    if ('ok' in res) {
+      // do nothing
+    } else {
+      return rejectWithValue({
+        error: res.err,
+      });
+    }
+  } catch {
+    return rejectWithValue({
+      error: {
+        other: 'Error occured during exhibiting NFT to child canisters.',
       },
     });
   }

--- a/src/NFTBarter_assets/src/features/exhibit/exhibitSlice.ts
+++ b/src/NFTBarter_assets/src/features/exhibit/exhibitSlice.ts
@@ -6,11 +6,9 @@ import {
   getChildCanisters,
   createChildCanister,
 } from '../childCanister/childCanisterSlice';
+import { transfer, reset } from '../transfer/transferSlice';
 
-import {
-  CanisterID,
-  Error,
-} from '../../../../declarations/NFTBarter/NFTBarter.did';
+import { Error } from '../../../../declarations/NFTBarter/NFTBarter.did';
 
 export interface ExhibitState {
   childCanisterId?: string;
@@ -21,9 +19,9 @@ const initialState: ExhibitState = {};
 
 export const exhibit = createAsyncThunk<
   ExhibitState,
-  undefined,
+  { tokenId: string },
   AsyncThunkConfig<{ error: Error }>
->('exhibit', async (_, { rejectWithValue, dispatch }) => {
+>('exhibit', async ({ tokenId }, { rejectWithValue, dispatch }) => {
   const authClient = await AuthClient.create();
 
   if (!authClient) {
@@ -60,7 +58,17 @@ export const exhibit = createAsyncThunk<
     // We will implement some logic to chose which child canister should be used.
     childCanisterId = childCanisterIds[0];
   }
-  console.log(childCanisterId);
+
+  // Transfer NFT to child canister
+  try {
+    await dispatch(transfer({ tokenId, childCanisterId }));
+  } catch {
+    return rejectWithValue({
+      error: {
+        other: 'Error occured during transfering NFT to child canisters.',
+      },
+    });
+  }
 
   return { childCanisterId };
 });

--- a/src/NFTBarter_assets/src/features/exhibit/exhibitSlice.ts
+++ b/src/NFTBarter_assets/src/features/exhibit/exhibitSlice.ts
@@ -1,17 +1,19 @@
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk, unwrapResult } from '@reduxjs/toolkit';
 import { AuthClient } from '@dfinity/auth-client';
-import { Identity } from '@dfinity/agent';
 
 import { RootState, AsyncThunkConfig } from '../../app/store';
-import { createNFTBarterActor } from '../../utils/createNFTBarterActor';
 import {
-  UserProfile,
-  Result,
+  getChildCanisters,
+  createChildCanister,
+} from '../childCanister/childCanisterSlice';
+
+import {
+  CanisterID,
   Error,
 } from '../../../../declarations/NFTBarter/NFTBarter.did';
-import { principalToAccountIdentifier } from '../../utils/ext';
 
 export interface ExhibitState {
+  childCanisterId?: string;
   error?: Error;
 }
 
@@ -21,14 +23,46 @@ export const exhibit = createAsyncThunk<
   ExhibitState,
   undefined,
   AsyncThunkConfig<{ error: Error }>
->('exhibit/implement', async (_, { rejectWithValue }) => {
+>('exhibit', async (_, { rejectWithValue, dispatch }) => {
   const authClient = await AuthClient.create();
 
   if (!authClient) {
     throw new Error('Failed to use auth client.');
   }
 
-  return rejectWithValue({ error: { other: '' } });
+  // Get user's child canister IDs.
+  let childCanisterIds: string[];
+  try {
+    const action = await dispatch(getChildCanisters());
+    const state = unwrapResult(action);
+    childCanisterIds = state.canisterIds;
+  } catch (rejectedValueOrSerializedError) {
+    return rejectWithValue({
+      error: { other: 'Error occured during fetching child canisters.' },
+    });
+  }
+
+  // If user does not have any child canister yet, create one.
+  let childCanisterId: string;
+  if (childCanisterIds.length === 0) {
+    try {
+      const action = await dispatch(createChildCanister());
+      const state = unwrapResult(action);
+      childCanisterId = state.canisterIds[0];
+    } catch (rejectedValueOrSerializedError) {
+      return rejectWithValue({
+        error: { other: 'Error occured during creating child canisters.' },
+      });
+    }
+  } else {
+    // So far, we use a child canister at 0-th index.
+    // However, user may have more than one child canister in future.
+    // We will implement some logic to chose which child canister should be used.
+    childCanisterId = childCanisterIds[0];
+  }
+  console.log(childCanisterId);
+
+  return { childCanisterId };
 });
 
 export const exhibitSlice = createSlice({
@@ -36,13 +70,17 @@ export const exhibitSlice = createSlice({
   initialState,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(exhibit.fulfilled, (state, action) => {});
+    builder.addCase(exhibit.fulfilled, (state, action) => {
+      state.childCanisterId = action.payload?.childCanisterId;
+    });
     builder.addCase(exhibit.rejected, (state, action) => {
       state.error = action.payload?.error;
     });
   },
 });
 
+export const selectChildCanisterId = (state: RootState) =>
+  state.exhibit.childCanisterId;
 export const selectError = (state: RootState) => state.exhibit.error;
 
 export default exhibitSlice.reducer;

--- a/src/NFTBarter_assets/src/features/exhibit/exhibitSlice.ts
+++ b/src/NFTBarter_assets/src/features/exhibit/exhibitSlice.ts
@@ -1,0 +1,48 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { AuthClient } from '@dfinity/auth-client';
+import { Identity } from '@dfinity/agent';
+
+import { RootState, AsyncThunkConfig } from '../../app/store';
+import { createNFTBarterActor } from '../../utils/createNFTBarterActor';
+import {
+  UserProfile,
+  Result,
+  Error,
+} from '../../../../declarations/NFTBarter/NFTBarter.did';
+import { principalToAccountIdentifier } from '../../utils/ext';
+
+export interface ExhibitState {
+  error?: Error;
+}
+
+const initialState: ExhibitState = {};
+
+export const exhibit = createAsyncThunk<
+  ExhibitState,
+  undefined,
+  AsyncThunkConfig<{ error: Error }>
+>('exhibit/implement', async (_, { rejectWithValue }) => {
+  const authClient = await AuthClient.create();
+
+  if (!authClient) {
+    throw new Error('Failed to use auth client.');
+  }
+
+  return rejectWithValue({ error: { other: '' } });
+});
+
+export const exhibitSlice = createSlice({
+  name: 'exhibit',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(exhibit.fulfilled, (state, action) => {});
+    builder.addCase(exhibit.rejected, (state, action) => {
+      state.error = action.payload?.error;
+    });
+  },
+});
+
+export const selectError = (state: RootState) => state.exhibit.error;
+
+export default exhibitSlice.reducer;

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import { Box, SimpleGrid, Center } from '@chakra-ui/react';
 
 import { GENERATIVE_ART_NFT_BASE_URL as baseUrl } from '../../utils/canisterId';
@@ -26,13 +25,11 @@ export const MyGenerativeArtNFTs = () => {
           const { tokenId, tokenIndex } = nft;
           return (
             <Box mx='auto' my='10px' key={tokenIndex}>
-              <Link to={`/asset/${tokenId}`}>
-                <NFTCard
-                  tokenId={tokenId}
-                  tokenIndex={tokenIndex}
-                  baseUrl={baseUrl}
-                />
-              </Link>
+              <NFTCard
+                tokenId={tokenId}
+                tokenIndex={tokenIndex}
+                baseUrl={baseUrl}
+              />
             </Box>
           );
         })}

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
@@ -17,11 +17,15 @@ export const MyGenerativeArtNFTs = () => {
 
   return (
     <Box maxW='1300px' mx='auto' mt='20px'>
-      <SimpleGrid mx='10px' spacing='10px' columns={{ base: 2, md: 3, lg: 4 }}>
+      <SimpleGrid
+        mx={{ base: '0px', md: '10px' }}
+        spacing='10px'
+        columns={{ base: 2, md: 3, lg: 4 }}
+      >
         {nfts.map((nft) => {
           const { tokenId, tokenIndex } = nft;
           return (
-            <Center my='10px' key={tokenIndex}>
+            <Box mx='auto' my='10px' key={tokenIndex}>
               <Link to={`/asset/${tokenId}`}>
                 <NFTCard
                   tokenId={tokenId}
@@ -29,7 +33,7 @@ export const MyGenerativeArtNFTs = () => {
                   baseUrl={baseUrl}
                 />
               </Link>
-            </Center>
+            </Box>
           );
         })}
       </SimpleGrid>

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/myGenerativeArtNFTSlice.ts
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/myGenerativeArtNFTSlice.ts
@@ -4,7 +4,10 @@ import { RootState, AsyncThunkConfig } from '../../app/store';
 import { generateTokenIdentifier } from '../../utils/ext';
 import { GENERATIVE_ART_NFT_CANISTER_ID as canisterId } from '../../utils/canisterId';
 
-import { User } from '../../../../declarations/GenerativeArtNFT/GenerativeArtNFT.did.js';
+import {
+  User,
+  TokenIdentifier,
+} from '../../../../declarations/GenerativeArtNFT/GenerativeArtNFT.did.js';
 import { createActor } from '../../../../declarations/GenerativeArtNFT';
 
 export interface GenerativeArtNFT {
@@ -57,7 +60,12 @@ export const fetchNFTs = createAsyncThunk<
 export const myGenerativeArtNFTSlice = createSlice({
   name: 'myGenerativeArtNFT',
   initialState,
-  reducers: {},
+  reducers: {
+    removeTokenById: (state, action) => {
+      const tokenId: TokenIdentifier = action.payload;
+      state.nfts = [...state.nfts.filter((t) => t.tokenId !== tokenId)];
+    },
+  },
   extraReducers: (builder) => {
     builder.addCase(fetchNFTs.fulfilled, (state, action) => {
       state.nfts = action.payload?.nfts;
@@ -68,6 +76,7 @@ export const myGenerativeArtNFTSlice = createSlice({
   },
 });
 
+export const { removeTokenById } = myGenerativeArtNFTSlice.actions;
 export const selectError = (state: RootState) => state.myGenerativeArtNFT.error;
 export const selectNfts = (state: RootState) => state.myGenerativeArtNFT.nfts;
 

--- a/src/NFTBarter_assets/src/features/transfer/transferSlice.ts
+++ b/src/NFTBarter_assets/src/features/transfer/transferSlice.ts
@@ -1,0 +1,128 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { AuthClient } from '@dfinity/auth-client';
+import { Principal } from '@dfinity/principal';
+
+import { RootState, AsyncThunkConfig } from '../../app/store';
+import { removeTokenById } from '../myGenerativeArtNFT/myGenerativeArtNFTSlice';
+import { GENERATIVE_ART_NFT_CANISTER_ID as canisterId } from '../../utils/canisterId';
+
+import {
+  User,
+  TokenIdentifier,
+  TransferRequest,
+  AccountIdentifier,
+} from '../../../../declarations/GenerativeArtNFT/GenerativeArtNFT.did';
+import { createActor } from '../../../../declarations/GenerativeArtNFT';
+
+type Error =
+  | {
+      CannotNotify: AccountIdentifier;
+    }
+  | {
+      InsufficientBalance: null;
+    }
+  | {
+      InvalidToken: TokenIdentifier;
+    }
+  | {
+      Rejected: null;
+    }
+  | {
+      Unauthorized: AccountIdentifier;
+    }
+  | {
+      Other: string;
+    };
+
+export interface TransferState {
+  success: boolean;
+  error?: Error;
+}
+
+const initialState: TransferState = {
+  success: false,
+};
+
+export const transfer = createAsyncThunk<
+  TransferState,
+  {
+    childCanisterId: string;
+    tokenId: TokenIdentifier;
+  },
+  AsyncThunkConfig<{ error: Error }>
+>(
+  'transfer',
+  async (
+    { tokenId, childCanisterId },
+    { rejectWithValue, getState, dispatch }
+  ) => {
+    const authClient = await AuthClient.create();
+
+    if (!authClient) {
+      return rejectWithValue({
+        error: { Unauthorized: 'Unauthorized error.' },
+      });
+    }
+
+    const identity = await authClient.getIdentity();
+    const actor = createActor(canisterId, {
+      agentOptions: { identity },
+    });
+
+    // Check if user owns childCanisterId
+    let childCanisterIds = getState().childCanister.canisterIds;
+    if (!childCanisterIds.find((c) => c === childCanisterId)) {
+      return rejectWithValue({
+        error: { Other: 'It is not your child canister.' },
+      });
+    }
+
+    // Transfer NFT to child canister
+    const user: User = {
+      principal: identity.getPrincipal(),
+    };
+    const childCanister: User = {
+      principal: Principal.fromText(childCanisterId),
+    };
+    const transferRequest: TransferRequest = {
+      from: user,
+      to: childCanister,
+      token: tokenId,
+      notify: false,
+      memo: [],
+      subaccount: [],
+      amount: BigInt(1),
+    };
+    const res = await actor.transfer(transferRequest);
+    if ('ok' in res) {
+      // Delist NFT card
+      dispatch(removeTokenById(tokenId));
+      return { success: true };
+    } else {
+      return rejectWithValue({ error: res.err });
+    }
+  }
+);
+
+export const transferSlice = createSlice({
+  name: 'transfer',
+  initialState,
+  reducers: {
+    reset: (state) => {
+      state.success = false;
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(transfer.fulfilled, (state, action) => {});
+    builder.addCase(transfer.rejected, (state, action) => {
+      state.error = action.payload?.error;
+    });
+  },
+});
+
+export const { reset } = transferSlice.actions;
+
+export const selectSuccess = (state: RootState) => state.transfer.success;
+export const selectError = (state: RootState) => state.transfer.error;
+
+export default transferSlice.reducer;

--- a/src/NFTBarter_assets/src/utils/createChildCanisterActor.ts
+++ b/src/NFTBarter_assets/src/utils/createChildCanisterActor.ts
@@ -1,0 +1,13 @@
+import { IDL } from '@dfinity/candid';
+
+declare module '../../../declarations/ChildCanister/ChildCanister.did.js' {
+  function idlFactory(): IDL.ServiceClass;
+}
+import {
+  _SERVICE as INFTBarter,
+  idlFactory,
+} from '../../../declarations/ChildCanister/ChildCanister.did.js';
+import { curriedCreateActor } from '../../../NFTBarter_assets/src/utils/createActor';
+
+export const createChildCanisterActorByCanisterId =
+  curriedCreateActor<INFTBarter>(idlFactory);

--- a/src/declarations/ChildCanister/ChildCanister.did
+++ b/src/declarations/ChildCanister/ChildCanister.did
@@ -1,0 +1,49 @@
+type UserId = principal;
+type TokenIdentifier = text;
+type Result_1 = 
+ variant {
+   err: Error;
+   ok;
+ };
+type Result = 
+ variant {
+   err: Error;
+   ok: nat;
+ };
+type Nft__1 = variant {myExtStandardNft: TokenIdentifier;};
+type NftStatus = 
+ variant {
+   Bid: Nft__1;
+   Exhibit: Nft__1;
+   Stay: Nft__1;
+ };
+type Nft = variant {myExtStandardNft: TokenIdentifier;};
+type Error = 
+ variant {
+   alreadyRegistered: text;
+   notYetRegistered: text;
+   other: text;
+   unauthorized: text;
+ };
+type ChildCanister = 
+ service {
+   exhibitMyNft: (nat) -> (Result_1);
+   getAssetOwners: () -> (vec record {
+                                nat;
+                                UserId;
+                              }) query;
+   getAssets: () -> (vec record {
+                           nat;
+                           NftStatus;
+                         }) query;
+   getAuctions: () -> (vec record {
+                             nat;
+                             vec record {
+                                   UserId;
+                                   nat;
+                                 };
+                           }) query;
+   importMyNft: (Nft) -> (Result);
+ };
+type CanisterIdList = record {myExtStandardNft: text;};
+service : (principal, CanisterIdList) -> ChildCanister

--- a/src/declarations/ChildCanister/ChildCanister.did.d.ts
+++ b/src/declarations/ChildCanister/ChildCanister.did.d.ts
@@ -1,0 +1,25 @@
+import type { Principal } from '@dfinity/principal';
+export interface CanisterIdList { 'myExtStandardNft' : string }
+export interface ChildCanister {
+  'exhibitMyNft' : (arg_0: bigint) => Promise<Result_1>,
+  'getAssetOwners' : () => Promise<Array<[bigint, UserId]>>,
+  'getAssets' : () => Promise<Array<[bigint, NftStatus]>>,
+  'getAuctions' : () => Promise<Array<[bigint, Array<[UserId, bigint]>]>>,
+  'importMyNft' : (arg_0: Nft) => Promise<Result>,
+}
+export type Error = { 'other' : string } |
+  { 'alreadyRegistered' : string } |
+  { 'unauthorized' : string } |
+  { 'notYetRegistered' : string };
+export type Nft = { 'myExtStandardNft' : TokenIdentifier };
+export type NftStatus = { 'Bid' : Nft__1 } |
+  { 'Stay' : Nft__1 } |
+  { 'Exhibit' : Nft__1 };
+export type Nft__1 = { 'myExtStandardNft' : TokenIdentifier };
+export type Result = { 'ok' : bigint } |
+  { 'err' : Error };
+export type Result_1 = { 'ok' : null } |
+  { 'err' : Error };
+export type TokenIdentifier = string;
+export type UserId = Principal;
+export interface _SERVICE extends ChildCanister {}

--- a/src/declarations/ChildCanister/ChildCanister.did.js
+++ b/src/declarations/ChildCanister/ChildCanister.did.js
@@ -1,0 +1,44 @@
+export const idlFactory = ({ IDL }) => {
+  const CanisterIdList = IDL.Record({ 'myExtStandardNft' : IDL.Text });
+  const Error = IDL.Variant({
+    'other' : IDL.Text,
+    'alreadyRegistered' : IDL.Text,
+    'unauthorized' : IDL.Text,
+    'notYetRegistered' : IDL.Text,
+  });
+  const Result_1 = IDL.Variant({ 'ok' : IDL.Null, 'err' : Error });
+  const UserId = IDL.Principal;
+  const TokenIdentifier = IDL.Text;
+  const Nft__1 = IDL.Variant({ 'myExtStandardNft' : TokenIdentifier });
+  const NftStatus = IDL.Variant({
+    'Bid' : Nft__1,
+    'Stay' : Nft__1,
+    'Exhibit' : Nft__1,
+  });
+  const Nft = IDL.Variant({ 'myExtStandardNft' : TokenIdentifier });
+  const Result = IDL.Variant({ 'ok' : IDL.Nat, 'err' : Error });
+  const ChildCanister = IDL.Service({
+    'exhibitMyNft' : IDL.Func([IDL.Nat], [Result_1], []),
+    'getAssetOwners' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(IDL.Nat, UserId))],
+        ['query'],
+      ),
+    'getAssets' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(IDL.Nat, NftStatus))],
+        ['query'],
+      ),
+    'getAuctions' : IDL.Func(
+        [],
+        [IDL.Vec(IDL.Tuple(IDL.Nat, IDL.Vec(IDL.Tuple(UserId, IDL.Nat))))],
+        ['query'],
+      ),
+    'importMyNft' : IDL.Func([Nft], [Result], []),
+  });
+  return ChildCanister;
+};
+export const init = ({ IDL }) => {
+  const CanisterIdList = IDL.Record({ 'myExtStandardNft' : IDL.Text });
+  return [IDL.Principal, CanisterIdList];
+};

--- a/src/declarations/ChildCanister/index.js
+++ b/src/declarations/ChildCanister/index.js
@@ -1,0 +1,38 @@
+import { Actor, HttpAgent } from "@dfinity/agent";
+
+// Imports and re-exports candid interface
+import { idlFactory } from './ChildCanister.did.js';
+export { idlFactory } from './ChildCanister.did.js';
+// CANISTER_ID is replaced by webpack based on node environment
+export const canisterId = process.env.CHILDCANISTER_CANISTER_ID;
+
+/**
+ * 
+ * @param {string | import("@dfinity/principal").Principal} canisterId Canister ID of Agent
+ * @param {{agentOptions?: import("@dfinity/agent").HttpAgentOptions; actorOptions?: import("@dfinity/agent").ActorConfig}} [options]
+ * @return {import("@dfinity/agent").ActorSubclass<import("./ChildCanister.did.js")._SERVICE>}
+ */
+ export const createActor = (canisterId, options) => {
+  const agent = new HttpAgent({ ...options?.agentOptions });
+  
+  // Fetch root key for certificate validation during development
+  if(process.env.NODE_ENV !== "production") {
+    agent.fetchRootKey().catch(err=>{
+      console.warn("Unable to fetch root key. Check to ensure that your local replica is running");
+      console.error(err);
+    });
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor(idlFactory, {
+    agent,
+    canisterId,
+    ...options?.actorOptions,
+  });
+};
+  
+/**
+ * A ready-to-use agent for the ChildCanister canister
+ * @type {import("@dfinity/agent").ActorSubclass<import("./ChildCanister.did.js")._SERVICE>}
+ */
+ export const ChildCanister = createActor(canisterId);

--- a/src/declarations/NFTBarter/NFTBarter.did
+++ b/src/declarations/NFTBarter/NFTBarter.did
@@ -1,4 +1,14 @@
 type UserProfile = variant {none;};
+type Result_2 = 
+ variant {
+   err: Error;
+   ok: vec CanisterID;
+ };
+type Result_1 = 
+ variant {
+   err: Error;
+   ok: CanisterID;
+ };
 type Result = 
  variant {
    err: Error;
@@ -6,9 +16,10 @@ type Result =
  };
 type NFTBarter = 
  service {
+   getMyChildCanisters: () -> (Result_2) query;
    getMyProfile: () -> (Result) query;
    isRegistered: () -> (bool) query;
-   mintChildCanister: () -> (principal);
+   mintChildCanister: () -> (Result_1);
    register: () -> (Result);
  };
 type Error = 
@@ -18,4 +29,5 @@ type Error =
    other: text;
    unauthorized: text;
  };
+type CanisterID = principal;
 service : () -> NFTBarter

--- a/src/declarations/NFTBarter/NFTBarter.did.d.ts
+++ b/src/declarations/NFTBarter/NFTBarter.did.d.ts
@@ -1,15 +1,21 @@
 import type { Principal } from '@dfinity/principal';
+export type CanisterID = Principal;
 export type Error = { 'other' : string } |
   { 'alreadyRegistered' : string } |
   { 'unauthorized' : string } |
   { 'notYetRegistered' : string };
 export interface NFTBarter {
+  'getMyChildCanisters' : () => Promise<Result_2>,
   'getMyProfile' : () => Promise<Result>,
   'isRegistered' : () => Promise<boolean>,
-  'mintChildCanister' : () => Promise<Principal>,
+  'mintChildCanister' : () => Promise<Result_1>,
   'register' : () => Promise<Result>,
 }
 export type Result = { 'ok' : UserProfile } |
+  { 'err' : Error };
+export type Result_1 = { 'ok' : CanisterID } |
+  { 'err' : Error };
+export type Result_2 = { 'ok' : Array<CanisterID> } |
   { 'err' : Error };
 export type UserProfile = { 'none' : null };
 export interface _SERVICE extends NFTBarter {}

--- a/src/declarations/NFTBarter/NFTBarter.did.js
+++ b/src/declarations/NFTBarter/NFTBarter.did.js
@@ -1,16 +1,20 @@
 export const idlFactory = ({ IDL }) => {
-  const UserProfile = IDL.Variant({ 'none' : IDL.Null });
+  const CanisterID = IDL.Principal;
   const Error = IDL.Variant({
     'other' : IDL.Text,
     'alreadyRegistered' : IDL.Text,
     'unauthorized' : IDL.Text,
     'notYetRegistered' : IDL.Text,
   });
+  const Result_2 = IDL.Variant({ 'ok' : IDL.Vec(CanisterID), 'err' : Error });
+  const UserProfile = IDL.Variant({ 'none' : IDL.Null });
   const Result = IDL.Variant({ 'ok' : UserProfile, 'err' : Error });
+  const Result_1 = IDL.Variant({ 'ok' : CanisterID, 'err' : Error });
   const NFTBarter = IDL.Service({
+    'getMyChildCanisters' : IDL.Func([], [Result_2], ['query']),
     'getMyProfile' : IDL.Func([], [Result], ['query']),
     'isRegistered' : IDL.Func([], [IDL.Bool], ['query']),
-    'mintChildCanister' : IDL.Func([], [IDL.Principal], []),
+    'mintChildCanister' : IDL.Func([], [Result_1], []),
     'register' : IDL.Func([], [Result], []),
   });
   return NFTBarter;

--- a/src/tests/e2e/mintChildCanister.test.ts
+++ b/src/tests/e2e/mintChildCanister.test.ts
@@ -1,0 +1,84 @@
+import { Secp256k1KeyIdentity } from '@dfinity/identity';
+import fetch from 'isomorphic-fetch';
+import { IDL } from '@dfinity/candid';
+
+declare module '../../declarations/NFTBarter/NFTBarter.did.js' {
+  function idlFactory(): IDL.ServiceClass;
+}
+import {
+  CanisterID,
+  _SERVICE as INFTBarter,
+  idlFactory,
+} from '../../declarations/NFTBarter/NFTBarter.did.js';
+import { curriedCreateActor } from '../../NFTBarter_assets/src/utils/createActor';
+import localCanisterIds from '../../../.dfx/local/canister_ids.json';
+
+const canisterId = localCanisterIds.NFTBarter.local;
+
+// We don't import `createNFTBarterActor` from `createNFTBarterActor.ts`
+// because it gives an error in jest running on GitHub Actions.
+const createNFTBarterActor =
+  curriedCreateActor<INFTBarter>(idlFactory)(canisterId);
+
+const identityOptionOfAlice = {
+  agentOptions: {
+    identity: Secp256k1KeyIdentity.generate(),
+    fetch,
+    host: 'http://localhost:8000',
+  },
+};
+const actorOfAlice = createNFTBarterActor(identityOptionOfAlice);
+
+const identityOptionOfAnonymous = {
+  agentOptions: {
+    fetch,
+    host: 'http://localhost:8000',
+  },
+};
+const actorOfAnonymous = createNFTBarterActor(identityOptionOfAnonymous);
+
+describe('Mint child canister test', () => {
+  let childCanisterId: CanisterID;
+
+  beforeAll(async () => {
+    await actorOfAlice.register();
+  });
+
+  it('Alice can mint a child canister', async () => {
+    const res = await actorOfAlice.mintChildCanister();
+    expect(res).toStrictEqual({
+      ok: expect.anything(),
+    });
+    if ('ok' in res) {
+      childCanisterId = res.ok;
+    }
+    expect(childCanisterId._isPrincipal).toBe(true);
+  });
+
+  it('Alice can get her child caniser', async () => {
+    let res = await actorOfAlice.getMyChildCanisters();
+    expect(res).toStrictEqual({
+      ok: [childCanisterId],
+    });
+  });
+});
+
+describe('Anonymous tests', () => {
+  it('Anomymous identity can not mint any child canister.', async () => {
+    const res = await actorOfAnonymous.mintChildCanister();
+    expect(res).toEqual({
+      err: {
+        unauthorized: expect.anything(),
+      },
+    });
+  });
+
+  it('Anonymous identity never has its own child canister.', async () => {
+    const res = await actorOfAnonymous.getMyChildCanisters();
+    expect(res).toEqual({
+      err: {
+        unauthorized: expect.anything(),
+      },
+    });
+  });
+});


### PR DESCRIPTION
# 概要・目的
NFTを出品するフロントエンドコードを実装する
<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
関連 #77
Fixes #28 

# 変更内容
## やったこと
- ExhibitボタンをNFTカードに追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/ccee55dfc0b4ff1682bef8a963a538020afd5934
- 出品の確認を行うModalを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/ed1ae8cdb2517e628929c2c6f77bea9349225d74
- 出品を管理する `features/exhibit` を追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/bffdce99e885a0e5b6737403a4d27e88ed0f02b1
- `childCanister` の生成・情報取得を管理する `features/childCanister` を追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/1a3cbedbe7b29c4a3b72cf6814af6099b0640767
- ユーザーが生成した `childCanister` をバックエンドから取得する `getMyChildCanisters` メソッドを `main.mo` に追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/58aeb4f7e36cb77e3b613fd3da5bd01cfb1b7739
- `mintChildCanister` のテストを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/60fa3d64742243e81a1d8a622a0d3f45371791e9
- child canister の取得・生成を`feature/childCanister`から行うロジックを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/7ff5c44dce356698c9bedc8a8f1438d1b79d9534
- `feature/exhibit` から child canister の情報取得・生成を行えるようにした https://github.com/Japan-DfinityInfoHub/nft-barter/commit/abec39c9bb335bab406e61cd325538f94aeeeea0
- NFTの転送を管理する `features/transfer` を追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/caf4b2ee114ecfe1f9e35aad300946c382708600
- Typo を修正 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/c2da25e5763e596a429a68d87e5e4208e75f1784
- `ChildCanister` の Candid ファイルを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/909a4e993bda1b58ae8e03a9f17afdbccda3ecc2
- `importMyNft` を `feature/exhibit` から呼び出すコードを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/a563fcbd9add5fbc731969249aaeb6770e628c13
- `exhibitMyNft` を `feature/exhibit` から呼び出すコードを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/a4c9c28d47b56aed5358ac0f279c7173138664e1
- `feature/exhibit` の進捗管理を行うためのステートを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/pull/78/commits/cb906eb0c0d56789410da98a33ee1d7bd7b4b343

<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
- #80 
- ChildCanister 生成時のICPの請求（デモの範囲外）
- #79 
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
- バックエンド
  - `main.mo` に新メソッド追加
  - `ChildCanister.mo` 内の変数名変更（Typo修正）
- フロントエンド
 - `features` 以下 `features/exhibit`, `features/transfer`, `features/childCanister` 
 - `ExhibitButton` 
- テスト
  - `mintChildCanister` の e2e テスト
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
プロフィール画面のNFTにExhibitボタンが追加されているので、クリック
![image](https://user-images.githubusercontent.com/40290137/172000688-6e9f7beb-3e59-4397-93c9-d11e2a92cd1d.png)
確認のモーダルが出てくるのでYESをクリック
![image](https://user-images.githubusercontent.com/40290137/172000717-24badd9f-6f78-4587-b3d3-8b99588af799.png)
出品したNFT（ここでは#28）がプロフィールから消えていることを確認
![image](https://user-images.githubusercontent.com/40290137/172000753-ed8f574c-d709-4c9d-9181-37b7f2a68343.png)
現状、出品済みのNFTを表示するページを作っていないため、今回はCandid UIから出品を確認した。
NFTが#Exhibitの状態でchild canister に保管されていることを目視確認。
![image](https://user-images.githubusercontent.com/40290137/172000782-f8e68594-995b-46f7-ae8c-45448236cdfb.png)


<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足
## 特にレビューして欲しい観点
- `main.mo` の `getMyChildCanisters` のロジックは問題ないか

## 注意点
現状、NFTの出品が終わる前にModalが閉じています（バックグラウンドでimportMyNftとexhibitMyNftの処理が続いている）。
やらないことに記載の通り、YESボタンを押した瞬間に進捗可視化画面に移行することを予定しており、本PRでModalタイミングの適正化は行っておりません。
<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
