### PR TITLE
Add display of exhibited NFTs on profile page

### DIFF
--- a/src/NFTBarter_assets/src/Components/NFTCard.tsx
+++ b/src/NFTBarter_assets/src/Components/NFTCard.tsx
@@ -1,16 +1,23 @@
 import React, { FC } from 'react';
 import { Link } from 'react-router-dom';
-import { Box, Image, Text, HStack, Spacer } from '@chakra-ui/react';
+import { Box, Image, Text, HStack, Spacer, Center } from '@chakra-ui/react';
 
 import { ExhibitButton } from '../features/exhibit/ExhibitButton';
+import { NftStatus } from '../features/myGenerativeArtNFT/myGenerativeArtNFTSlice';
 
 interface Props {
   tokenId: string;
   tokenIndex: number;
   baseUrl: string;
+  status: NftStatus;
 }
 
-export const NFTCard: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
+export const NFTCard: FC<Props> = ({
+  tokenId,
+  tokenIndex,
+  baseUrl,
+  status,
+}) => {
   return (
     <Box
       minWidth='150px'
@@ -34,11 +41,25 @@ export const NFTCard: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
         >{`# ${tokenIndex}`}</Text>
         <Spacer />
         <Box p='10px'>
-          <ExhibitButton
-            tokenId={tokenId}
-            tokenIndex={tokenIndex}
-            baseUrl={baseUrl}
-          />
+          {status === 'wallet' && (
+            <ExhibitButton
+              tokenId={tokenId}
+              tokenIndex={tokenIndex}
+              baseUrl={baseUrl}
+            />
+          )}
+          {status === 'exhibit' && (
+            <Center
+              color='white'
+              px='1em'
+              fontSize={{ base: 'sm', md: 'md' }}
+              height='2em'
+              borderRadius='xl'
+              bgColor='blue.300'
+            >
+              <Text fontWeight='semibold'>Exhibited</Text>
+            </Center>
+          )}
         </Box>
       </HStack>
     </Box>

--- a/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
+++ b/src/NFTBarter_assets/src/features/exhibit/ExhibitButton.tsx
@@ -9,7 +9,7 @@ import {
 
 import { useAppDispatch } from '../../app/hooks';
 import { exhibit, reset } from './exhibitSlice';
-import { removeTokenById } from '../myGenerativeArtNFT/myGenerativeArtNFTSlice';
+import { updateNft } from '../myGenerativeArtNFT/myGenerativeArtNFTSlice';
 import { ConfirmationModalContent } from './ConfirmationModalContent';
 import { ProgressModalContent } from './ProgressModalContent';
 
@@ -33,7 +33,7 @@ export const ExhibitButton: FC<Props> = ({ tokenId, tokenIndex, baseUrl }) => {
     setIsProgress(true);
     await dispatch(exhibit({ tokenId }));
     await new Promise((resolve) => setTimeout(resolve, 500));
-    dispatch(removeTokenById(tokenId));
+    dispatch(updateNft({ tokenId, tokenIndex, status: 'exhibit' }));
     setIsProgress(false);
   };
 

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
@@ -4,14 +4,14 @@ import { Box, SimpleGrid, Center } from '@chakra-ui/react';
 import { GENERATIVE_ART_NFT_BASE_URL as baseUrl } from '../../utils/canisterId';
 import { NFTCard } from './../../Components/NFTCard';
 import { useAppSelector, useAppDispatch } from '../../app/hooks';
-import { fetchNFTs, selectNfts } from './myGenerativeArtNFTSlice';
+import { fetchNFTsOnWallet, selectNfts } from './myGenerativeArtNFTSlice';
 
 export const MyGenerativeArtNFTs = () => {
   const dispatch = useAppDispatch();
   const nfts = useAppSelector(selectNfts);
 
   useEffect(() => {
-    dispatch(fetchNFTs());
+    dispatch(fetchNFTsOnWallet());
   }, []);
 
   return (

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/MyGenerativeArtNFTs.tsx
@@ -4,14 +4,19 @@ import { Box, SimpleGrid, Center } from '@chakra-ui/react';
 import { GENERATIVE_ART_NFT_BASE_URL as baseUrl } from '../../utils/canisterId';
 import { NFTCard } from './../../Components/NFTCard';
 import { useAppSelector, useAppDispatch } from '../../app/hooks';
-import { fetchNFTsOnWallet, selectNfts } from './myGenerativeArtNFTSlice';
+import {
+  fetchNFTsOnWallet,
+  fetchNFTsOnChildCanister,
+  selectAllNfts,
+} from './myGenerativeArtNFTSlice';
 
 export const MyGenerativeArtNFTs = () => {
   const dispatch = useAppDispatch();
-  const nfts = useAppSelector(selectNfts);
+  const allNfts = useAppSelector(selectAllNfts);
 
   useEffect(() => {
     dispatch(fetchNFTsOnWallet());
+    dispatch(fetchNFTsOnChildCanister());
   }, []);
 
   return (
@@ -21,12 +26,13 @@ export const MyGenerativeArtNFTs = () => {
         spacing='10px'
         columns={{ base: 2, md: 3, lg: 4 }}
       >
-        {nfts.map((nft) => {
-          const { tokenId, tokenIndex } = nft;
+        {allNfts.map((nft) => {
+          const { tokenId, tokenIndex, status } = nft;
           return (
             <Box mx='auto' my='10px' key={tokenIndex}>
               <NFTCard
                 tokenId={tokenId}
+                status={status}
                 tokenIndex={tokenIndex}
                 baseUrl={baseUrl}
               />

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/myGenerativeArtNFTSlice.ts
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/myGenerativeArtNFTSlice.ts
@@ -10,9 +10,19 @@ import {
 } from '../../../../declarations/GenerativeArtNFT/GenerativeArtNFT.did.js';
 import { createActor } from '../../../../declarations/GenerativeArtNFT';
 
+const NftStatus = {
+  WALLET: 'wallet',
+  EXHIBIT: 'exhibit',
+  BIT: 'bit',
+} as const;
+
+// type NftStatus = "wallet" | "exhibit" | "bit"
+type NftStatus = typeof NftStatus[keyof typeof NftStatus];
+
 export interface GenerativeArtNFT {
   tokenId: string;
   tokenIndex: number;
+  status: NftStatus;
 }
 
 export interface MyGenerativeArtNFTState {
@@ -24,11 +34,11 @@ const initialState: MyGenerativeArtNFTState = {
   nfts: [],
 };
 
-export const fetchNFTs = createAsyncThunk<
+export const fetchNFTsOnWallet = createAsyncThunk<
   MyGenerativeArtNFTState,
   undefined,
   AsyncThunkConfig<{ error: string }>
->('myGenerativeArtNFT/fetchNFTs', async (_, { rejectWithValue }) => {
+>('myGenerativeArtNFT/fetchNFTsOnWallet', async (_, { rejectWithValue }) => {
   const authClient = await AuthClient.create();
 
   if (!authClient || !authClient.isAuthenticated()) {
@@ -49,7 +59,7 @@ export const fetchNFTs = createAsyncThunk<
     return {
       nfts: (await actor.getTokenIndexOwnedByUser(user)).map((tokenIndex) => {
         const tokenId = generateTokenIdentifier(canisterId, tokenIndex);
-        return { tokenId, tokenIndex };
+        return { tokenId, tokenIndex, status: 'wallet' };
       }),
     };
   } catch {
@@ -67,10 +77,10 @@ export const myGenerativeArtNFTSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addCase(fetchNFTs.fulfilled, (state, action) => {
+    builder.addCase(fetchNFTsOnWallet.fulfilled, (state, action) => {
       state.nfts = action.payload?.nfts;
     });
-    builder.addCase(fetchNFTs.rejected, (state, action) => {
+    builder.addCase(fetchNFTsOnWallet.rejected, (state, action) => {
       state.error = action.payload?.error;
     });
   },

--- a/src/NFTBarter_assets/src/features/myGenerativeArtNFT/myGenerativeArtNFTSlice.ts
+++ b/src/NFTBarter_assets/src/features/myGenerativeArtNFT/myGenerativeArtNFTSlice.ts
@@ -1,8 +1,11 @@
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk, unwrapResult } from '@reduxjs/toolkit';
 import { AuthClient } from '@dfinity/auth-client';
 import { RootState, AsyncThunkConfig } from '../../app/store';
-import { generateTokenIdentifier } from '../../utils/ext';
+import { generateTokenIdentifier, decodeTokenId } from '../../utils/ext';
 import { GENERATIVE_ART_NFT_CANISTER_ID as canisterId } from '../../utils/canisterId';
+import { createChildCanisterActorByCanisterId } from '../../utils/createChildCanisterActor';
+
+import { getChildCanisters } from '../childCanister/childCanisterSlice';
 
 import {
   User,
@@ -12,12 +15,16 @@ import { createActor } from '../../../../declarations/GenerativeArtNFT';
 
 const NftStatus = {
   WALLET: 'wallet',
+  STAY: 'stay',
   EXHIBIT: 'exhibit',
-  BIT: 'bit',
+  BID: 'bid',
 } as const;
 
-// type NftStatus = "wallet" | "exhibit" | "bit"
-type NftStatus = typeof NftStatus[keyof typeof NftStatus];
+// type NftStatus = "wallet" | "stay" | "exhibit" | "bid"
+export type NftStatus = typeof NftStatus[keyof typeof NftStatus];
+
+const compareNft = (a: GenerativeArtNFT, b: GenerativeArtNFT) =>
+  a.tokenIndex - b.tokenIndex;
 
 export interface GenerativeArtNFT {
   tokenId: string;
@@ -26,13 +33,77 @@ export interface GenerativeArtNFT {
 }
 
 export interface MyGenerativeArtNFTState {
-  nfts: GenerativeArtNFT[];
+  nftsOnWallet: GenerativeArtNFT[];
+  nftsOnChildCanisters: GenerativeArtNFT[];
   error?: string;
 }
 
 const initialState: MyGenerativeArtNFTState = {
-  nfts: [],
+  nftsOnWallet: [],
+  nftsOnChildCanisters: [],
 };
+
+export const fetchNFTsOnChildCanister = createAsyncThunk<
+  MyGenerativeArtNFTState,
+  undefined,
+  AsyncThunkConfig<{ error: string }>
+>(
+  'myGenerativeArtNFT/fetchNFTsOnChildCanister',
+  async (_, { rejectWithValue, dispatch }) => {
+    const authClient = await AuthClient.create();
+
+    if (!authClient || !authClient.isAuthenticated()) {
+      return rejectWithValue({ error: 'Failed to use auth client.' });
+    }
+
+    const identity = await authClient.getIdentity();
+
+    let childCanisterIds: string[];
+    try {
+      const action = await dispatch(getChildCanisters());
+      const state = unwrapResult(action);
+      childCanisterIds = state.canisterIds;
+    } catch (rejectedValueOrSerializedError) {
+      return rejectWithValue({
+        error: 'Error occured during fetching child canisters.',
+      });
+    }
+
+    const nfts = await Promise.all(
+      childCanisterIds.map(async (childCanisterId) => {
+        const actor = createChildCanisterActorByCanisterId(childCanisterId)({
+          agentOptions: { identity },
+        });
+        const assets = await actor.getAssets();
+        const nfts: GenerativeArtNFT[] = assets.map((asset) => {
+          const [_, stat] = asset;
+          let tokenId: TokenIdentifier;
+          let nftStatus: NftStatus;
+          if ('Stay' in stat) {
+            tokenId = stat.Stay.myExtStandardNft;
+            nftStatus = 'stay';
+          } else if ('Exhibit' in stat) {
+            tokenId = stat.Exhibit.myExtStandardNft;
+            nftStatus = 'exhibit';
+          } else if ('Bid' in stat) {
+            tokenId = stat.Bid.myExtStandardNft;
+            nftStatus = 'bid';
+          } else {
+            throw new Error('Invalid token');
+          }
+          const { index } = decodeTokenId(tokenId);
+          return {
+            tokenId,
+            tokenIndex: index,
+            status: nftStatus,
+          };
+        });
+        return nfts;
+      })
+    );
+    return { nftsOnChildCanisters: nfts.flat(), nftsOnWallet: [] };
+  }
+);
 
 export const fetchNFTsOnWallet = createAsyncThunk<
   MyGenerativeArtNFTState,
@@ -57,10 +128,13 @@ export const fetchNFTsOnWallet = createAsyncThunk<
 
   try {
     return {
-      nfts: (await actor.getTokenIndexOwnedByUser(user)).map((tokenIndex) => {
-        const tokenId = generateTokenIdentifier(canisterId, tokenIndex);
-        return { tokenId, tokenIndex, status: 'wallet' };
-      }),
+      nftsOnWallet: (await actor.getTokenIndexOwnedByUser(user)).map(
+        (tokenIndex) => {
+          const tokenId = generateTokenIdentifier(canisterId, tokenIndex);
+          return { tokenId, tokenIndex, status: 'wallet' };
+        }
+      ),
+      nftsOnChildCanisters: [],
     };
   } catch {
     return rejectWithValue({ error: 'Mint failed.' });
@@ -71,23 +145,52 @@ export const myGenerativeArtNFTSlice = createSlice({
   name: 'myGenerativeArtNFT',
   initialState,
   reducers: {
-    removeTokenById: (state, action) => {
-      const tokenId: TokenIdentifier = action.payload;
-      state.nfts = [...state.nfts.filter((t) => t.tokenId !== tokenId)];
+    updateNft(state, action: { payload: GenerativeArtNFT }) {
+      const updatedNft = action.payload;
+      if (updatedNft.status === 'wallet') {
+        // Remove the NFT from nftsOnChildCanisters and add it to nftsOnWallet
+        state.nftsOnChildCanisters = state.nftsOnChildCanisters.filter(
+          (nft) => nft.tokenId !== updatedNft.tokenId
+        );
+        state.nftsOnWallet = [...state.nftsOnWallet, updatedNft];
+      } else {
+        // Remove the NFT from nftsOnWallet and add it to nftsOnChildCanisters
+        state.nftsOnWallet = state.nftsOnWallet.filter(
+          (nft) => nft.tokenId !== updatedNft.tokenId
+        );
+        state.nftsOnChildCanisters = [
+          ...state.nftsOnChildCanisters,
+          updatedNft,
+        ];
+      }
     },
   },
   extraReducers: (builder) => {
     builder.addCase(fetchNFTsOnWallet.fulfilled, (state, action) => {
-      state.nfts = action.payload?.nfts;
+      state.nftsOnWallet = action.payload?.nftsOnWallet;
     });
     builder.addCase(fetchNFTsOnWallet.rejected, (state, action) => {
+      state.error = action.payload?.error;
+    });
+    builder.addCase(fetchNFTsOnChildCanister.fulfilled, (state, action) => {
+      state.nftsOnChildCanisters = action.payload?.nftsOnChildCanisters;
+    });
+    builder.addCase(fetchNFTsOnChildCanister.rejected, (state, action) => {
       state.error = action.payload?.error;
     });
   },
 });
 
-export const { removeTokenById } = myGenerativeArtNFTSlice.actions;
-export const selectError = (state: RootState) => state.myGenerativeArtNFT.error;
-export const selectNfts = (state: RootState) => state.myGenerativeArtNFT.nfts;
+export const { updateNft } = myGenerativeArtNFTSlice.actions;
 
+export const selectError = (state: RootState) => state.myGenerativeArtNFT.error;
+export const selectNftsOnWallet = (state: RootState) =>
+  state.myGenerativeArtNFT.nftsOnWallet.sort(compareNft);
+export const selectNftsOnChildCanister = (state: RootState) =>
+  state.myGenerativeArtNFT.nftsOnChildCanisters.sort(compareNft);
+export const selectAllNfts = (state: RootState) =>
+  [
+    ...state.myGenerativeArtNFT.nftsOnWallet,
+    ...state.myGenerativeArtNFT.nftsOnChildCanisters,
+  ].sort(compareNft);
 export default myGenerativeArtNFTSlice.reducer;


### PR DESCRIPTION
# 概要・目的
出品済みのNFTの一覧を表示する
<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
Fixes #79 
Fixes #77

# 変更内容
## やったこと
- フロントエンド側にNFT のステータス（wallet/exhibit/bit）を追加 https://github.com/Japan-DfinityInfoHub/nft-barter/pull/82/commits/bbe44bf2e47a07ed4f2ea60aa5f7a4cfb778d297
- childCanister上のNFTを取得するメソッドを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/pull/82/commits/b1f08f4d0cd7eb41ca698f34ea7c07add2d7a139
- NFTCardをNFTのステータスによって表示切り替え https://github.com/Japan-DfinityInfoHub/nft-barter/pull/82/commits/fd2b20293c9e05d876e6b14d0d5bffb8168d8118
<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
- 出品済／未済のNFTをフィルタして表示する機能の開発
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
フロントエンド
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
- Profile画面にchild canister 上のNFTも表示されるようになる（Exhibitedと表示される）
- 出品するとExhibitボタンがExhibitedに変わる

![画面収録_2022-06-05_22_20_29_AdobeCreativeCloudExpress](https://user-images.githubusercontent.com/40290137/172052701-a5cd3067-271e-4d51-80c4-c437e8930559.gif)

<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足

<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
