### PR TITLE
Extract GenerativeArtNFT canister id as stable var

### DIFF
--- a/src/NFTBarter/main.mo
+++ b/src/NFTBarter/main.mo
@@ -30,6 +30,9 @@ shared (install) actor class NFTBarter() = this {
     _stableCanisters.vals(), 10, Principal.equal, Principal.hash
   );
 
+  // The target NFT (GenerativeArtNFT) caniter id.
+  stable var _targetNftCanisterId : CanisterID = Principal.fromText("r7inp-6aaaa-aaaaa-aaabq-cai");
+
   // Register `caller` as a new user.
   // Returns `caller` if the registration process successfully finishes.
   // Traps if:
@@ -72,7 +75,7 @@ shared (install) actor class NFTBarter() = this {
   public shared ({ caller }) func mintChildCanister(): async Result<CanisterID, Error> {
     if (Principal.isAnonymous(caller)) { return #err(#unauthorized(Principal.toText(caller))) };
 
-    let child = await ChildCanister.ChildCanister(caller, {myExtStandardNft="r7inp-6aaaa-aaaaa-aaabq-cai"});
+    let child = await ChildCanister.ChildCanister(caller, {myExtStandardNft=Principal.toText(_targetNftCanisterId)});
     _childCanisters.put(Principal.fromActor(child), caller);
     #ok (Principal.fromActor(child))
   };
@@ -87,6 +90,18 @@ shared (install) actor class NFTBarter() = this {
     #ok (Iter.toArray(Iter.map<(CanisterID, UserId), CanisterID>(canisterIdsOfUser, func (entry) {
       entry.0
     })))
+  };
+
+  // Set the target NFT canister id.
+  public shared ({ caller }) func updateTargetNftCanisterId(newCanisterId: CanisterID): async Result<CanisterID, Error> {
+    if (caller != installer) { return #err(#unauthorized(Principal.toText(caller))) };
+
+    _targetNftCanisterId := newCanisterId;
+    #ok (_targetNftCanisterId)
+  };
+
+  public query func getTargetNftCanisterId(): async CanisterID {
+    _targetNftCanisterId
   };
 
   /* system functions */

--- a/src/NFTBarter_assets/src/features/auth/authSlice.ts
+++ b/src/NFTBarter_assets/src/features/auth/authSlice.ts
@@ -6,7 +6,7 @@ import { RootState, AsyncThunkConfig } from '../../app/store';
 import { createNFTBarterActor } from '../../utils/createNFTBarterActor';
 import {
   UserProfile,
-  Result,
+  Result_1,
   Error,
 } from '../../../../declarations/NFTBarter/NFTBarter.did';
 import { principalToAccountIdentifier } from '../../utils/ext';
@@ -33,7 +33,7 @@ const getMyProfile = async (identity: Identity) => {
 };
 
 const promisedLogin = (authClient: AuthClient) =>
-  new Promise<{ res: Result; principal: string }>(async (resolve, reject) => {
+  new Promise<{ res: Result_1; principal: string }>(async (resolve, reject) => {
     try {
       await authClient.login({
         onSuccess: async () => {
@@ -44,10 +44,10 @@ const promisedLogin = (authClient: AuthClient) =>
             const isRegistered = await actor.isRegistered();
             const principal = identity.getPrincipal().toText();
 
-            // Return `{ res: Result; principal: string }` here because
+            // Return `{ res: Result_1; principal: string }` here because
             // `UserProfile` currently does not contain principal id.
             // We may add `id: Principal` to `UserProfile` in the backend canister
-            // so that this function can simply return `Result`.
+            // so that this function can simply return `Result_1`.
             if (!isRegistered) {
               resolve({
                 res: await actor.register(),

--- a/src/declarations/NFTBarter/NFTBarter.did
+++ b/src/declarations/NFTBarter/NFTBarter.did
@@ -7,20 +7,22 @@ type Result_2 =
 type Result_1 = 
  variant {
    err: Error;
-   ok: CanisterID;
+   ok: UserProfile;
  };
 type Result = 
  variant {
    err: Error;
-   ok: UserProfile;
+   ok: CanisterID;
  };
 type NFTBarter = 
  service {
    getMyChildCanisters: () -> (Result_2) query;
-   getMyProfile: () -> (Result) query;
+   getMyProfile: () -> (Result_1) query;
+   getTargetNftCanisterId: () -> (CanisterID) query;
    isRegistered: () -> (bool) query;
-   mintChildCanister: () -> (Result_1);
-   register: () -> (Result);
+   mintChildCanister: () -> (Result);
+   register: () -> (Result_1);
+   updateTargetNftCanisterId: (CanisterID) -> (Result);
  };
 type Error = 
  variant {

--- a/src/declarations/NFTBarter/NFTBarter.did.d.ts
+++ b/src/declarations/NFTBarter/NFTBarter.did.d.ts
@@ -6,14 +6,16 @@ export type Error = { 'other' : string } |
   { 'notYetRegistered' : string };
 export interface NFTBarter {
   'getMyChildCanisters' : () => Promise<Result_2>,
-  'getMyProfile' : () => Promise<Result>,
+  'getMyProfile' : () => Promise<Result_1>,
+  'getTargetNftCanisterId' : () => Promise<CanisterID>,
   'isRegistered' : () => Promise<boolean>,
-  'mintChildCanister' : () => Promise<Result_1>,
-  'register' : () => Promise<Result>,
+  'mintChildCanister' : () => Promise<Result>,
+  'register' : () => Promise<Result_1>,
+  'updateTargetNftCanisterId' : (arg_0: CanisterID) => Promise<Result>,
 }
-export type Result = { 'ok' : UserProfile } |
+export type Result = { 'ok' : CanisterID } |
   { 'err' : Error };
-export type Result_1 = { 'ok' : CanisterID } |
+export type Result_1 = { 'ok' : UserProfile } |
   { 'err' : Error };
 export type Result_2 = { 'ok' : Array<CanisterID> } |
   { 'err' : Error };

--- a/src/declarations/NFTBarter/NFTBarter.did.js
+++ b/src/declarations/NFTBarter/NFTBarter.did.js
@@ -8,14 +8,16 @@ export const idlFactory = ({ IDL }) => {
   });
   const Result_2 = IDL.Variant({ 'ok' : IDL.Vec(CanisterID), 'err' : Error });
   const UserProfile = IDL.Variant({ 'none' : IDL.Null });
-  const Result = IDL.Variant({ 'ok' : UserProfile, 'err' : Error });
-  const Result_1 = IDL.Variant({ 'ok' : CanisterID, 'err' : Error });
+  const Result_1 = IDL.Variant({ 'ok' : UserProfile, 'err' : Error });
+  const Result = IDL.Variant({ 'ok' : CanisterID, 'err' : Error });
   const NFTBarter = IDL.Service({
     'getMyChildCanisters' : IDL.Func([], [Result_2], ['query']),
-    'getMyProfile' : IDL.Func([], [Result], ['query']),
+    'getMyProfile' : IDL.Func([], [Result_1], ['query']),
+    'getTargetNftCanisterId' : IDL.Func([], [CanisterID], ['query']),
     'isRegistered' : IDL.Func([], [IDL.Bool], ['query']),
-    'mintChildCanister' : IDL.Func([], [Result_1], []),
-    'register' : IDL.Func([], [Result], []),
+    'mintChildCanister' : IDL.Func([], [Result], []),
+    'register' : IDL.Func([], [Result_1], []),
+    'updateTargetNftCanisterId' : IDL.Func([CanisterID], [Result], []),
   });
   return NFTBarter;
 };


### PR DESCRIPTION
# 概要・目的

<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
Fixes #74 

# 変更内容
## やったこと
- ハードコードされている部分（NFTのCanisterID）のstable変数化 & 更新func追加
<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
- https://github.com/Japan-DfinityInfoHub/nft-barter/issues/76
- および`updateTargetNftCanisterId`自身のテスト
(installerからのcallをtsからテストするのは厄介なため本PRのスコープ外とする。 Ref. https://github.com/Japan-DfinityInfoHub/generative-art-nft/pull/24)
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
- バックエンド
- フロントエンド (Candidに更新がかかったため)
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
dfx call経由でCanisterIDを更新後、testが全てpassすることを確認.
<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足
CandidのResult、既存の状態を変更せずに"追加"する方法って無いですかね？
(Candid Resultの"追加"でははく"変更"になったため、参照していたフロント部分を修正する必要が出た)
<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
