### PR TITLE
Add feature for auction about bidding and selecting

### DIFF
--- a/src/NFTBarter/ChildCanister.mo
+++ b/src/NFTBarter/ChildCanister.mo
@@ -102,16 +102,18 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
     // Check Owner
     if (isOwner(tokenIndex) == false) return #err(#unauthorized("You are not the owner of this NFT"));
 
-    // Change `NftStatus` to `#Exhibit`
-    changeNftStatus(tokenIndex, returnExhibit);
-
     // Start Bater Auction
     switch (_auctions.get(tokenIndex)) {
-      // _
-      case (?_) assert(false);
-      case (null) _auctions.put(tokenIndex, 
-        HashMap.HashMap<UserId, TokenIndex>(0, Principal.equal, Principal.hash)
-      )
+      case (?_) {
+        return #err(#other("The auction has already started"))
+      };
+      case (null) {
+        let bids = HashMap.HashMap<UserId, TokenIndex>(0, Principal.equal, Principal.hash);
+        _auctions.put(tokenIndex, bids);
+
+        // Change `NftStatus` to `#Exhibit`
+        changeNftStatus(tokenIndex, returnExhibit);
+      }
     };
 
     return #ok;

--- a/src/NFTBarter/ChildCanister.mo
+++ b/src/NFTBarter/ChildCanister.mo
@@ -54,6 +54,7 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
             case (#Stay(v)) v;
             case (#Bid(v)) v;
             case (#Exhibit(v)) v;
+            case (#Pending(v)) v;
           };
           nft==_nft
         }
@@ -122,6 +123,40 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
   };
 
   /* Bid Methods */
+  // public shared ({caller}) func offerBidMyNft({bidToken : Nat; exhibitToken : Nat; famliyId : CanisterID}) : async Result<(), Error> {
+  //   // Check Auth
+  //   if (Principal.isAnonymous(caller) or (caller != _canisterOwner)) 
+  //     { return #err(#unauthorized(Principal.toText(caller))) };
+
+  //   // Check Owner
+  //   switch (_assetOwners.get(bidToken)) {
+  //     case (null) return #err(#notYetRegistered(""));
+  //     case (?owner) {
+  //       if (owner != _canisterOwner) return #err(#unauthorized(""));
+  //     }
+  //   };
+
+  //   // Check it is famliy
+
+
+  //   // peddingにする必要がある．
+
+
+  //   // Call AcceptOffer Function
+  //   let famliyCanister = actor(famliyId) : {
+  //     acceptOffer : () -> async ();
+  //   };
+  //   switch (await famliyCanister.acceptOffer()) {
+  //     case (#err(_)) return #err(#other("Error In famliyCanister.acceptOffer"));
+  //     case (#ok(_)) {};
+  //   };
+
+  //   // 
+
+
+
+
+  // };
 
 
   /* Helper Methods */

--- a/src/NFTBarter/ChildCanister.mo
+++ b/src/NFTBarter/ChildCanister.mo
@@ -39,6 +39,9 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
   let _auctions = HashMap.HashMap<Nat, HashMap.HashMap<UserId, Nat>>(
     0, Nat.equal, Hash.hash
   );
+  let parentCanister = actor(Principal.toText(installer)) : actor {
+  isFamliy : Text -> async Bool;
+  };
 
   /* Exhibit Methods */
   public shared ({caller}) func importMyNft(nft : Nft) : async Result<Nat, Error> {
@@ -52,8 +55,8 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
         _assets.entries(), func(index, nftStatus) {
           let _nft = switch (nftStatus) {
             case (#Stay(v)) v;
-            case (#BidOffered(v)) v;
-            case (#BidOffering(v)) v;
+            case (#BidOffered(v)) v.nft;
+            case (#BidOffering(v)) v.nft;
             case (#Exhibit(v)) v;
             case (#Pending(v)) v;
           };
@@ -121,32 +124,78 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
     // Check Owner
     if (isOwner(bidToken) == false) return #err(#unauthorized(""));
 
-    // Check it is famliy
-    let parentCanister = actor(Principal.toText(installer)) : actor {
-      isFamliy : Text -> async Bool;
-    };
+    // Check it is Famliy
     if ((await parentCanister.isFamliy(famliyId)) == false) return #err(#unauthorized(""));
 
     // Change NftStatus to #Pending
     changeNftStatus(bidToken, returnPending);
 
     // Call AcceptOffer Function
-    let famliyCanister = actor(famliyId) : actor {
-      acceptOffer : () -> async Result<(), Error>;
-    };
-    switch (await famliyCanister.acceptOffer()) {
+    switch (await (actor(famliyId) : Types.ChildCanisterIF).acceptOffer()) {
       case (#err(_)) { // fail sendToMe
         changeNftStatus(bidToken, returnStay);
-        return #err(#other("Error In famliyCanister.acceptOffer"))
+        return #err(#other("Error In x.acceptOffer()"))
       };
       case (#ok(_)) {};
     };
 
-    // Change NftStatus to #BidOffering
-    changeNftStatus(bidToken, returnBidOffering);
-    
-    return #ok;
+    // Change NftStatus to #BidOffering // WIP bid先のcanisterIdとかを記憶しておく必要がある．
+    changeNftStatus(bidToken, returnBidOffering(famliyId, exhibitToken));
 
+    return #ok;
+  };
+
+  public shared ({caller}) func acceptBidOffer({bidToken : Nat; exhibitToken : Nat;}) : async Result<(), Error> {
+    if (Principal.isAnonymous(caller)) return #err(#unauthorized(""));
+
+    // Check Caller is Famliy
+    if ((await parentCanister.isFamliy(Principal.toText(caller))) == false) return #err(#unauthorized(""));
+
+    // Change NftStatus to #Pending // ここではいらないはず
+
+    // sendToMe
+    let (nft, owner) = switch (await (actor(Principal.toText(caller)) : Types.ChildCanisterIF).sendToMe(bidToken)) {
+      case (#err(_)) return #err(#other("Error In x.sendToMe()"));
+      case (#ok(nft, owner)) (nft, owner);
+    };
+
+    // Register BidOffered Nft;
+    switch (nft) {
+      case (#MyExtStandartNft(extTokenIdentifier)) {
+        tokenIndex += 1;
+        _assets.put(tokenIndex, #BidOffered({
+          nft = #MyExtStandartNft(extTokenIdentifier);
+          from = Principal.toText(caller);
+          exhibitNftIndex = exhibitToken;
+        }));
+        _assetOwners.put(tokenIndex, owner);
+      }
+    };
+
+    // add bid to _auction // WIP 
+
+    return #ok;
+  };
+
+  public shared ({caller}) func sendToMe(token : Nat) : async Result<(Nft, UserId), Error> {
+    if (Principal.isAnonymous(caller)) return #err(#unauthorized(""));
+
+    // penddingにcanister idを追加して，ここでチェックする
+
+    // nft情報を取り出す
+    let nft = switch (_assets.get(token)) {
+      case (null) return #err(#other("assert(false)"));
+      case (?nftStatus) switch (nftStatus) {
+        case (#Pending(v)) v;
+        case (_) return #err(#other("assert(false)"));
+      }
+    };
+
+    // trasfer Nft to caller
+
+    // if it is ok, return ok
+
+    return #ok(nft, caller);
   };
 
 
@@ -173,9 +222,25 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
   };
   func returnStay(nft : Nft)    : NftStatus {#Stay(nft)};
   func returnExhibit(nft : Nft) : NftStatus {#Exhibit(nft)};
-  func returnBidOffered(nft : Nft)  : NftStatus {#BidOffered(nft)};
-  func returnBidOffering(nft : Nft) : NftStatus {#BidOffering(nft)};
   func returnPending(nft : Nft) : NftStatus {#Pending(nft)};
+  func returnBidOffered(from : Text, exhibitNftIndex : Nat) : Nft -> NftStatus {
+    return func (nft : Nft) : NftStatus { // Currying
+      #BidOffered({
+        nft;
+        from;
+        exhibitNftIndex;
+      })
+    }
+  };
+  func returnBidOffering(to : Text, exhibitNftIndex : Nat) : Nft -> NftStatus {
+    return func (nft : Nft) : NftStatus { // Currying
+      #BidOffering({
+        nft;
+        to;
+        exhibitNftIndex;
+      })
+    }
+  };
 
 
   // query

--- a/src/NFTBarter/ChildCanister.mo
+++ b/src/NFTBarter/ChildCanister.mo
@@ -9,6 +9,7 @@ import Result "mo:base/Result";
 import Principal "mo:base/Principal";
 import Blob "mo:base/Blob";
 import Iter "mo:base/Iter";
+import ExtTypes "./NftTypes/ExtTypes";
 
 shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal, _canisterIdList : Types.CanisterIdList) = this {
   /* Local Types */
@@ -21,6 +22,7 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
   type Nft = Types.Nft;
   type TokenIndex = Types.TokenIndex;
   type CanisterIDText = Types.CanisterIDText;
+  type TokenIdentifier = Types.TokenIdentifier;
 
   /* Nfts Types */
   // Sample Nft
@@ -61,25 +63,12 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
     // Import Nft
     switch (nft) {
       case (#MyExtStandardNft(tokenIdentifier)) 
-        switch (
-          // Confirm posession of NFT by transfering NFT to myself
-          await (actor(_canisterIdList.myExtStandardNft): MyExtStandardNftCanisterIF)
-            .transfer({
-              from = #principal(Principal.fromActor(this));
-              to = #principal(Principal.fromActor(this));
-              token = tokenIdentifier;
-              amount = 1;
-              memo = Blob.fromArray([]:[Nat8]);
-              notify = false;
-              subaccount = null;
-            })
-        ) {
-          case (#err(_)) return #err(#unauthorized("You are not the owner of this NFT"));
-          case (#ok(_)) {
-            totalTokenIndex += 1;
-            _assets.put(totalTokenIndex, #Stay(#MyExtStandardNft(tokenIdentifier)));
-            _assetOwners.put(totalTokenIndex, _canisterOwner);
-          };
+        if (await hasNft(tokenIdentifier)) {
+          totalTokenIndex += 1;
+          _assets.put(totalTokenIndex, #Stay(#MyExtStandardNft(tokenIdentifier)));
+          _assetOwners.put(totalTokenIndex, _canisterOwner);
+        } else {
+          return #err(#unauthorized("You are not the owner of this NFT"));
         };
       // new nft is added here
     };
@@ -116,6 +105,8 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
   };
 
   /* Bid Methods */
+
+  // Note that `caller` of this method is a bidding user.
   public shared ({caller}) func offerBidMyNft({bidToken : TokenIndex; exhibitToken : TokenIndex; exhibitCanisterId : CanisterIDText}) : async Result<(), Error> {
     // Check Auth
     if (Principal.isAnonymous(caller) or (caller != _canisterOwner)) {
@@ -128,11 +119,14 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
     // Check if `exhibitCanisterId` is famliy
     if ((await parentCanister.isFamily(exhibitCanisterId)) == false) return #err(#unauthorized(exhibitCanisterId # " is not our family."));
 
-    // Change NftStatus to #Pending
-    changeNftStatus(bidToken, returnPending);
+    // Specify recipient (`exhibitCanisterId`) as a parameter of `returnPending` while changing `NftStatus` to `#Pending`
+    changeNftStatus(bidToken, returnPending(exhibitCanisterId));
 
     // Call `acceptBitOffer` function in `exhibitCanisterId`
-    switch (await (actor(exhibitCanisterId) : Types.ChildCanisterIF).acceptBidOffer()) {
+    switch (await (actor(exhibitCanisterId) : Types.ChildCanisterIF).acceptBidOffer({
+      bidToken = bidToken;
+      exhibitToken = exhibitToken;
+    })) {
       // In case `acceptBidOffer` fails, change `NftStatus` back to `#Stay`
       case (#err(_)) {
         changeNftStatus(bidToken, returnStay);
@@ -146,15 +140,16 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
     };
   };
 
+  // Note that `caller` of this method is a child canister of the bidding user.
   public shared ({caller}) func acceptBidOffer({bidToken : TokenIndex; exhibitToken : TokenIndex;}) : async Result<(), Error> {
     if (Principal.isAnonymous(caller)) return #err(#unauthorized("You are not authorized."));
 
     // Check if `caller` is family
     if ((await parentCanister.isFamily(Principal.toText(caller))) == false) return #err(#unauthorized(Principal.toText(caller) # "is not our family."));
 
-    // Check if auction is open
+    // Check if auction is open here, before transferring NFTs
     if (isAuctionOpen(exhibitToken) == false) return #err(#other("Auction does not exist."));
-    
+
     // sendToMe
     let nft = switch (await (actor(Principal.toText(caller)) : Types.ChildCanisterIF).sendToMe(bidToken)) {
       case (#err _) return #err(#other("An error occurred during call to sendToMe function."));
@@ -174,7 +169,13 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
       };
     };
 
-    // add bid to _auction // WIP 
+    // Add bid to `_auctions`
+    switch (_auctions.get(exhibitToken)){
+      case (null) assert(false); // Must not be called
+      case (?auction) {
+        auction.put(caller, bidToken);
+      }
+    };
 
     return #ok;
   };
@@ -182,22 +183,46 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
   public shared ({caller}) func sendToMe(tokenIndex : TokenIndex) : async Result<Nft, Error> {
     if (Principal.isAnonymous(caller)) return #err(#unauthorized("You are not authorized."));
 
-    // penddingにcanister idを追加して，ここでチェックする
-
-    // nft情報を取り出す
-    let nft = switch (_assets.get(tokenIndex)) {
+    let (nft, recipient) = switch (_assets.get(tokenIndex)) {
       case (null) return #err(#other("NFT does not exist."));
       case (?nftStatus) switch (nftStatus) {
-        case (#Pending(v)) v;
-        case (_) return #err(#other("assert(false)"));
+        case (#Pending(v)){ 
+          // Check recipient of NFT
+          if (v.recipient != Principal.toText(caller)) {
+            return #err(#unauthorized("You are not authorized."))
+          };
+          (v.nft, v.recipient)
+        };
+        case (_) return #err(#other("Invalid NFT status (which must be #Pending)"));
       }
     };
 
-    // trasfer Nft to caller
-
-    // if it is ok, return ok
-
-    return #ok nft;
+    // Transfer the NFT to `recipient`
+    switch (nft) {
+      case (#MyExtStandardNft(tokenIdentifier)) {
+        if (await hasNft(tokenIdentifier)) {
+          switch (await (actor(_canisterIdList.myExtStandardNft): MyExtStandardNftCanisterIF)
+            .transfer({
+              from = #principal(Principal.fromActor(this));
+              to = #principal(Principal.fromText(recipient));
+              token = tokenIdentifier;
+              amount = 1;
+              memo = Blob.fromArray([]:[Nat8]);
+              notify = false;
+              subaccount = null;
+            })){
+            case (#err(_)){
+              return #err(#other("An error occurred while transferring NFT"));
+            };
+            case (#ok(_)){
+              return #ok nft;
+            };
+          };
+        } else {
+          return #err(#unauthorized("You are not the owner of this NFT"));
+        };
+      };
+    };
   };
 
 
@@ -211,11 +236,13 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
   };
 
   // Change `NftStatus` by applying `returnStatus` function
+  // Note that `NftStatus` can be changed only when it is either `#Stay` or `#Pending`
   func changeNftStatus(tokenIndex : TokenIndex, returnStatus : Nft -> NftStatus) {
     switch (_assets.get(tokenIndex)) {
       case (null) assert(false);
       case (?nftStatus) switch (nftStatus) {
         case (#Stay(nft)) _assets.put(tokenIndex, returnStatus(nft));
+        case (#Pending(v)) _assets.put(tokenIndex, returnStatus(v.nft));
         case (_) assert(false);
       }
     }
@@ -247,18 +274,43 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
       case (#BidOffered(v)) v.nft;
       case (#BidOffering(v)) v.nft;
       case (#Exhibit(nft)) nft;
-      case (#Pending(nft)) nft;
+      case (#Pending(v)) v.nft;
     }
+  };
+
+  // Check posession of NFT by transfering NFT to myself
+  func hasNft(tokenIdentifier : TokenIdentifier) : async Bool {
+    switch (await (actor(_canisterIdList.myExtStandardNft): MyExtStandardNftCanisterIF)
+      .transfer({
+        from = #principal(Principal.fromActor(this));
+        to = #principal(Principal.fromActor(this));
+        token = tokenIdentifier;
+        amount = 1;
+        memo = Blob.fromArray([]:[Nat8]);
+        notify = false;
+        subaccount = null;
+      })){
+      case (#err(_)) return false;
+      case (#ok(_)) return true;
+    };
   };
 
   /* `returnStatus` functions */
   func returnStay(nft : Nft)    : NftStatus {#Stay(nft)};
 
   func returnExhibit(nft : Nft) : NftStatus {#Exhibit(nft)};
+  
+  // Return function which takes nft as parameter and returns `NftStatus` of `#Pending`
+  func returnPending(recipient: CanisterIDText) : Nft -> NftStatus {
+    return func (nft: Nft) : NftStatus {
+      #Pending({
+        recipient;
+        nft;
+      })
+    }
+  };
 
-  func returnPending(nft : Nft) : NftStatus {#Pending(nft)};
-
-  // Returns function which takes nft as parameter and returns `NftStatus` with `#BidOffered`
+  // Returns function which takes nft as parameter and returns `NftStatus` of `#BidOffered`
   func returnBidOffered(from : CanisterIDText, exhibitNftIndex : TokenIndex) : Nft -> NftStatus {
     return func (nft : Nft) : NftStatus {
       #BidOffered({
@@ -269,7 +321,7 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
     }
   };
 
-  // Returns function which takes nft as parameter and returns `NftStatus` with `#BidOffering`
+  // Returns function which takes nft as parameter and returns `NftStatus` of `#BidOffering`
   func returnBidOffering(to : CanisterIDText, exhibitNftIndex : TokenIndex) : Nft -> NftStatus {
     return func (nft : Nft) : NftStatus {
       #BidOffering({
@@ -287,6 +339,13 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
 
   public query func getAssetOwners() : async [(TokenIndex, UserId)] {
     Iter.toArray(_assetOwners.entries())
+  };
+
+  public query func getAssetOwnerByTokenIndex(tokenIndex: TokenIndex) : async Result<UserId, Error> {
+    switch (_assetOwners.get(tokenIndex)){
+      case (null) return #err(#other("Asset is not found."));
+      case (?owner) return #ok(owner);
+    }
   };
 
   public query func getAuctions() : async [(TokenIndex, [(UserId, TokenIndex)])] {

--- a/src/NFTBarter/ChildCanister.mo
+++ b/src/NFTBarter/ChildCanister.mo
@@ -70,7 +70,8 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
         } else {
           return #err(#unauthorized("You are not the owner of this NFT"));
         };
-      // new nft is added here
+      // New nft will be added here.
+      // case(#NewNft(id)) {};
     };
     return #ok totalTokenIndex;
   };
@@ -170,6 +171,8 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
         }));
         _assetOwners.put(totalTokenIndex, caller);
       };
+      // New nft will be added here.
+      // case(#NewNft(id)) {};
     };
 
     // Add bid to `_auctions`
@@ -203,28 +206,26 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
     // Transfer the NFT to `recipient`
     switch (nft) {
       case (#MyExtStandardNft(tokenIdentifier)) {
-        if (await hasNft(tokenIdentifier)) {
-          switch (await (actor(_canisterIdList.myExtStandardNft): MyExtStandardNftCanisterIF)
-            .transfer({
-              from = #principal(Principal.fromActor(this));
-              to = #principal(Principal.fromText(recipient));
-              token = tokenIdentifier;
-              amount = 1;
-              memo = Blob.fromArray([]:[Nat8]);
-              notify = false;
-              subaccount = null;
-            })){
-            case (#err(_)){
-              return #err(#other("An error occurred while transferring NFT"));
-            };
-            case (#ok(_)){
-              return #ok nft;
-            };
+        switch (await (actor(_canisterIdList.myExtStandardNft): MyExtStandardNftCanisterIF)
+          .transfer({
+            from = #principal(Principal.fromActor(this));
+            to = #principal(Principal.fromText(recipient));
+            token = tokenIdentifier;
+            amount = 1;
+            memo = Blob.fromArray([]:[Nat8]);
+            notify = false;
+            subaccount = null;
+          })){
+          case (#err(_)){
+            return #err(#other("An error occurred while transferring NFT"));
           };
-        } else {
-          return #err(#unauthorized("You are not the owner of this NFT"));
+          case (#ok(_)){
+            return #ok nft;
+          };
         };
       };
+      // New nft will be added here.
+      // case(#NewNft(id)) {};
     };
   };
 
@@ -253,13 +254,12 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
       index != selectedToken
     });
 
-    let bid = switch (selectedBid) {
+    let bidder = switch (selectedBid) {
       case (null) return #err(#other("Bid is not found."));
-      case (?bid) bid;
+      case (?bid) bid.1;
     };
 
     // Swap owner
-    let bidder = bid.1;
     _assetOwners.put(exhibitToken, bidder);
     _assetOwners.put(selectedToken, Principal.fromActor(this));
 
@@ -294,7 +294,7 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
       case (?ns) { ns };
     };
 
-    let newStatus = switch (oldNftStatus) {
+    let newNftStatus = switch (oldNftStatus) {
       case (#Stay(nft)) returnStatus(nft);
       case (#Pending(v)) returnStatus(v.nft);
       case (#Exhibit(nft)) {
@@ -315,7 +315,7 @@ shared ({caller=installer}) actor class ChildCanister(_canisterOwner : Principal
     };
 
     // Apply new status
-    _assets.put(tokenIndex, newStatus);
+    _assets.put(tokenIndex, newNftStatus);
     
   };
 

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -5,15 +5,15 @@
 import Result "mo:base/Result";
 // import Principal "mo:base/Principal";
 
-
 // import Ext-Standart Types
 import ExtTypes "./NftTypes/ExtTypes";
-
 
 module {
 
   public type UserId = Principal;
   public type CanisterID = Principal;
+  public type TokenIndex = Nat;
+  public type CanisterIDText = Text;
 
   public type UserProfile = {
     #none;
@@ -26,8 +26,6 @@ module {
     #other : Text;
   };
 
-
-
   /* For Child Canister */
   // Parent Types
   public type ParentIF = actor {
@@ -35,7 +33,7 @@ module {
   };
 
   public type CanisterIdList = {
-    myExtStandardNft : Text;
+    myExtStandardNft : CanisterIDText;
   };
 
   // All Nft Type
@@ -48,13 +46,13 @@ module {
     #Stay : Nft;
     #BidOffered : {
       nft : Nft;
-      from : Text;
-      exhibitNftIndex : Nat;
+      from : CanisterIDText;
+      exhibitNftIndex : TokenIndex;
     };
     #BidOffering : {
       nft : Nft;
-      to : Text;
-      exhibitNftIndex : Nat;
+      to : CanisterIDText;
+      exhibitNftIndex : TokenIndex;
     };
     #Exhibit : Nft;
     #Pending : Nft;
@@ -81,8 +79,7 @@ module {
 
   public type ChildCanisterIF = actor {
     acceptBidOffer : () -> async Result.Result<(), Error>;
-    sendToMe : Nat -> async Result.Result<Nft, Error>;
+    sendToMe : TokenIndex -> async Result.Result<Nft, Error>;
   }
-
 
 }

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -14,6 +14,7 @@ module {
   public type CanisterID = Principal;
   public type TokenIndex = Nat;
   public type CanisterIDText = Text;
+  public type TokenIdentifier = ExtTypes.TokenIdentifier;
 
   public type UserProfile = {
     #none;
@@ -39,7 +40,7 @@ module {
   // All Nft Type
   public type Nft = {
     // #SampleNft;
-    #MyExtStandardNft : ExtTypes.TokenIdentifier;
+    #MyExtStandardNft : TokenIdentifier;
   };
   
   public type NftStatus = {
@@ -55,7 +56,10 @@ module {
       exhibitNftIndex : TokenIndex;
     };
     #Exhibit : Nft;
-    #Pending : Nft;
+    #Pending : {
+      recipient : CanisterIDText;
+      nft : Nft;
+    };
   };
 
   // Import Request
@@ -78,7 +82,7 @@ module {
   };
 
   public type ChildCanisterIF = actor {
-    acceptBidOffer : () -> async Result.Result<(), Error>;
+    acceptBidOffer : ({ bidToken: TokenIndex; exhibitToken : TokenIndex;}) -> async Result.Result<(), Error>;
     sendToMe : TokenIndex -> async Result.Result<Nft, Error>;
   }
 

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -47,7 +47,8 @@ module {
   public type NftStatus = {
     #Stay : Nft;
     #Bid : Nft;
-    #Exhibit : Nft
+    #Exhibit : Nft;
+    #Pending : Nft;
   };
 
   // Import Request

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -80,8 +80,8 @@ module {
   };
 
   public type ChildCanisterIF = actor {
-    acceptOffer : () -> async Result.Result<(), Error>;
-    sendToMe : Nat -> async Result.Result<(Nft, UserId), Error>;
+    acceptBidOffer : () -> async Result.Result<(), Error>;
+    sendToMe : Nat -> async Result.Result<Nft, Error>;
   }
 
 

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -46,7 +46,8 @@ module {
   
   public type NftStatus = {
     #Stay : Nft;
-    #Bid : Nft;
+    #BidOffered : Nft;
+    #BidOffering : Nft;
     #Exhibit : Nft;
     #Pending : Nft;
   };

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -56,10 +56,13 @@ module {
       exhibitNftIndex : TokenIndex;
     };
     #Exhibit : Nft;
+    #ExhibitEnd: Nft;
     #Pending : {
       recipient : CanisterIDText;
       nft : Nft;
     };
+    #Selected : Nft;
+    #NotSelected : Nft;
   };
 
   // Import Request
@@ -80,10 +83,5 @@ module {
   public type MyExtStandardNftCanisterIF = actor {
     transfer : ExtTypes.TransferRequest -> async ExtTypes.TransferResponse;
   };
-
-  public type ChildCanisterIF = actor {
-    acceptBidOffer : ({ bidToken: TokenIndex; exhibitToken : TokenIndex;}) -> async Result.Result<(), Error>;
-    sendToMe : TokenIndex -> async Result.Result<Nft, Error>;
-  }
 
 }

--- a/src/NFTBarter/Types.mo
+++ b/src/NFTBarter/Types.mo
@@ -46,8 +46,16 @@ module {
   
   public type NftStatus = {
     #Stay : Nft;
-    #BidOffered : Nft;
-    #BidOffering : Nft;
+    #BidOffered : {
+      nft : Nft;
+      from : Text;
+      exhibitNftIndex : Nat;
+    };
+    #BidOffering : {
+      nft : Nft;
+      to : Text;
+      exhibitNftIndex : Nat;
+    };
     #Exhibit : Nft;
     #Pending : Nft;
   };
@@ -69,6 +77,12 @@ module {
   // };
   public type MyExtStandardNftCanisterIF = actor {
     transfer : ExtTypes.TransferRequest -> async ExtTypes.TransferResponse;
+  };
+
+  public type ChildCanisterIF = actor {
+    acceptOffer : () -> async Result.Result<(), Error>;
+    sendToMe : Nat -> async Result.Result<(Nft, UserId), Error>;
   }
+
 
 }

--- a/src/NFTBarter/main.mo
+++ b/src/NFTBarter/main.mo
@@ -14,6 +14,7 @@ shared (install) actor class NFTBarter() = this {
   type UserProfile = Types.UserProfile;
   type UserId = Types.UserId;
   type CanisterID = Types.CanisterID;
+  type CanisterIDText = Types.CanisterIDText;
   type Error = Types.Error;
   type Result<T, E> = Result.Result<T, E>;
 
@@ -98,6 +99,14 @@ shared (install) actor class NFTBarter() = this {
 
     _targetNftCanisterId := newCanisterId;
     #ok (_targetNftCanisterId)
+  };
+
+  // Returns true if `canisterId` is in `_childCanisters`
+  public shared func isFamily(canisterId: CanisterIDText) : async Bool {
+    switch (_childCanisters.get(Principal.fromText(canisterId))) {
+      case null { return false };
+      case (?_) { return true };
+    };
   };
 
   public query func getTargetNftCanisterId(): async CanisterID {

--- a/src/NFTBarter_assets/src/models/NftModel.ts
+++ b/src/NFTBarter_assets/src/models/NftModel.ts
@@ -2,12 +2,16 @@ const NftStatus = {
   WALLET: 'wallet',
   STAY: 'stay',
   EXHIBIT: 'exhibit',
+  EXHIBITEND: 'exhibitEnd',
   BIDOFFERING: 'bidOffering',
   BIDOFFERED: 'bidOffered',
   PENDING: 'pending',
+  SELECTED: 'selected',
+  NOTSELECTED: 'notSelected',
 } as const;
 
-// type NftStatus = "wallet" | "stay" | "exhibit" | "bidOffering" | "bidOffered" | "pending"
+// type NftStatus = "wallet" | "stay" | "exhibit" | "exhibitEnd" | "bidOffering" |
+// "bidOffered" | "pending" | "selected" | "notSelected"
 export type NftStatus = typeof NftStatus[keyof typeof NftStatus];
 
 export const compareNft = (a: GenerativeArtNFT, b: GenerativeArtNFT) =>

--- a/src/NFTBarter_assets/src/models/NftModel.ts
+++ b/src/NFTBarter_assets/src/models/NftModel.ts
@@ -2,10 +2,12 @@ const NftStatus = {
   WALLET: 'wallet',
   STAY: 'stay',
   EXHIBIT: 'exhibit',
-  BID: 'bid',
+  BIDOFFERING: 'bidOffering',
+  BIDOFFERED: 'bidOffered',
+  PENDING: 'pending',
 } as const;
 
-// type NftStatus = "wallet" | "stay" | "exhibit" | "bid"
+// type NftStatus = "wallet" | "stay" | "exhibit" | "bidOffering" | "bidOffered" | "pending"
 export type NftStatus = typeof NftStatus[keyof typeof NftStatus];
 
 export const compareNft = (a: GenerativeArtNFT, b: GenerativeArtNFT) =>

--- a/src/NFTBarter_assets/src/utils/nft.ts
+++ b/src/NFTBarter_assets/src/utils/nft.ts
@@ -47,6 +47,9 @@ export const getTokenIdAndNftStatusFromAsset = (
   } else if ('Exhibit' in stat) {
     tokenId = stat.Exhibit.MyExtStandardNft;
     nftStatus = 'exhibit';
+  } else if ('ExhibitEnd' in stat) {
+    tokenId = stat.ExhibitEnd.MyExtStandardNft;
+    nftStatus = 'exhibitEnd';
   } else if ('BidOffering' in stat) {
     tokenId = stat.BidOffering.nft.MyExtStandardNft;
     nftStatus = 'bidOffering';
@@ -56,6 +59,12 @@ export const getTokenIdAndNftStatusFromAsset = (
   } else if ('Pending' in stat) {
     tokenId = stat.Pending.nft.MyExtStandardNft;
     nftStatus = 'pending';
+  } else if ('Selected' in stat) {
+    tokenId = stat.Selected.MyExtStandardNft;
+    nftStatus = 'selected';
+  } else if ('NotSelected' in stat) {
+    tokenId = stat.NotSelected.MyExtStandardNft;
+    nftStatus = 'notSelected';
   } else {
     throw new Error('Invalid token');
   }

--- a/src/declarations/ChildCanister/ChildCanister.did
+++ b/src/declarations/ChildCanister/ChildCanister.did
@@ -2,10 +2,23 @@ type UserId = principal;
 type TokenIndex__1 = nat;
 type TokenIndex = nat;
 type TokenIdentifier = text;
-type Result_3 = 
+type Result_5 = 
+ variant {
+   err: Error;
+   ok: NftStatus;
+ };
+type Result_4 = 
  variant {
    err: Error;
    ok: UserId;
+ };
+type Result_3 = 
+ variant {
+   err: Error;
+   ok: vec record {
+             TokenIndex;
+             UserId;
+           };
  };
 type Result_2 = 
  variant {
@@ -38,10 +51,13 @@ type NftStatus =
       to: CanisterIDText;
     };
    Exhibit: Nft__1;
+   ExhibitEnd: Nft__1;
+   NotSelected: Nft__1;
    Pending: record {
               nft: Nft__1;
               recipient: CanisterIDText;
             };
+   Selected: Nft__1;
    Stay: Nft__1;
  };
 type Nft = variant {MyExtStandardNft: TokenIdentifier;};
@@ -58,9 +74,10 @@ type ChildCanister =
     (record {
        bidToken: TokenIndex;
        exhibitToken: TokenIndex;
-     }) -> (Result_1);
+     }) -> (Result_2);
    exhibitMyNft: (TokenIndex) -> (Result_1);
-   getAssetOwnerByTokenIndex: (TokenIndex) -> (Result_3) query;
+   getAssetByTokenIndex: (TokenIndex) -> (Result_5) query;
+   getAssetOwnerByTokenIndex: (TokenIndex) -> (Result_4) query;
    getAssetOwners: () -> (vec record {
                                 TokenIndex;
                                 UserId;
@@ -69,12 +86,13 @@ type ChildCanister =
                            TokenIndex;
                            NftStatus;
                          }) query;
+   getAuctionByTokenIndex: (TokenIndex) -> (Result_3) query;
    getAuctions: () ->
     (vec record {
            TokenIndex;
            vec record {
-                 UserId;
                  TokenIndex;
+                 UserId;
                };
          }) query;
    importMyNft: (Nft) -> (Result_2);
@@ -83,6 +101,11 @@ type ChildCanister =
        bidToken: TokenIndex;
        exhibitCanisterId: CanisterIDText__1;
        exhibitToken: TokenIndex;
+     }) -> (Result_2);
+   selectTokenInAuction:
+    (record {
+       exhibitToken: TokenIndex;
+       selectedToken: TokenIndex;
      }) -> (Result_1);
    sendToMe: (TokenIndex) -> (Result);
  };

--- a/src/declarations/ChildCanister/ChildCanister.did
+++ b/src/declarations/ChildCanister/ChildCanister.did
@@ -1,5 +1,17 @@
 type UserId = principal;
+type TokenIndex__1 = nat;
+type TokenIndex = nat;
 type TokenIdentifier = text;
+type Result_3 = 
+ variant {
+   err: Error;
+   ok: UserId;
+ };
+type Result_2 = 
+ variant {
+   err: Error;
+   ok: TokenIndex;
+ };
 type Result_1 = 
  variant {
    err: Error;
@@ -8,13 +20,28 @@ type Result_1 =
 type Result = 
  variant {
    err: Error;
-   ok: nat;
+   ok: Nft;
  };
 type Nft__1 = variant {MyExtStandardNft: TokenIdentifier;};
 type NftStatus = 
  variant {
-   Bid: Nft__1;
+   BidOffered:
+    record {
+      exhibitNftIndex: TokenIndex__1;
+      from: CanisterIDText;
+      nft: Nft__1;
+    };
+   BidOffering:
+    record {
+      exhibitNftIndex: TokenIndex__1;
+      nft: Nft__1;
+      to: CanisterIDText;
+    };
    Exhibit: Nft__1;
+   Pending: record {
+              nft: Nft__1;
+              recipient: CanisterIDText;
+            };
    Stay: Nft__1;
  };
 type Nft = variant {MyExtStandardNft: TokenIdentifier;};
@@ -27,23 +54,39 @@ type Error =
  };
 type ChildCanister = 
  service {
-   exhibitMyNft: (nat) -> (Result_1);
+   acceptBidOffer:
+    (record {
+       bidToken: TokenIndex;
+       exhibitToken: TokenIndex;
+     }) -> (Result_1);
+   exhibitMyNft: (TokenIndex) -> (Result_1);
+   getAssetOwnerByTokenIndex: (TokenIndex) -> (Result_3) query;
    getAssetOwners: () -> (vec record {
-                                nat;
+                                TokenIndex;
                                 UserId;
                               }) query;
    getAssets: () -> (vec record {
-                           nat;
+                           TokenIndex;
                            NftStatus;
                          }) query;
-   getAuctions: () -> (vec record {
-                             nat;
-                             vec record {
-                                   UserId;
-                                   nat;
-                                 };
-                           }) query;
-   importMyNft: (Nft) -> (Result);
+   getAuctions: () ->
+    (vec record {
+           TokenIndex;
+           vec record {
+                 UserId;
+                 TokenIndex;
+               };
+         }) query;
+   importMyNft: (Nft) -> (Result_2);
+   offerBidMyNft:
+    (record {
+       bidToken: TokenIndex;
+       exhibitCanisterId: CanisterIDText__1;
+       exhibitToken: TokenIndex;
+     }) -> (Result_1);
+   sendToMe: (TokenIndex) -> (Result);
  };
-type CanisterIdList = record {myExtStandardNft: text;};
+type CanisterIdList = record {myExtStandardNft: CanisterIDText;};
+type CanisterIDText__1 = text;
+type CanisterIDText = text;
 service : (principal, CanisterIdList) -> ChildCanister

--- a/src/declarations/ChildCanister/ChildCanister.did.d.ts
+++ b/src/declarations/ChildCanister/ChildCanister.did.d.ts
@@ -1,25 +1,61 @@
 import type { Principal } from '@dfinity/principal';
-export interface CanisterIdList { 'myExtStandardNft' : string }
+export type CanisterIDText = string;
+export type CanisterIDText__1 = string;
+export interface CanisterIdList { 'myExtStandardNft' : CanisterIDText }
 export interface ChildCanister {
-  'exhibitMyNft' : (arg_0: bigint) => Promise<Result_1>,
-  'getAssetOwners' : () => Promise<Array<[bigint, UserId]>>,
-  'getAssets' : () => Promise<Array<[bigint, NftStatus]>>,
-  'getAuctions' : () => Promise<Array<[bigint, Array<[UserId, bigint]>]>>,
-  'importMyNft' : (arg_0: Nft) => Promise<Result>,
+  'acceptBidOffer' : (
+      arg_0: { 'bidToken' : TokenIndex, 'exhibitToken' : TokenIndex },
+    ) => Promise<Result_1>,
+  'exhibitMyNft' : (arg_0: TokenIndex) => Promise<Result_1>,
+  'getAssetOwnerByTokenIndex' : (arg_0: TokenIndex) => Promise<Result_3>,
+  'getAssetOwners' : () => Promise<Array<[TokenIndex, UserId]>>,
+  'getAssets' : () => Promise<Array<[TokenIndex, NftStatus]>>,
+  'getAuctions' : () => Promise<
+      Array<[TokenIndex, Array<[UserId, TokenIndex]>]>
+    >,
+  'importMyNft' : (arg_0: Nft) => Promise<Result_2>,
+  'offerBidMyNft' : (
+      arg_0: {
+        'exhibitCanisterId' : CanisterIDText__1,
+        'bidToken' : TokenIndex,
+        'exhibitToken' : TokenIndex,
+      },
+    ) => Promise<Result_1>,
+  'sendToMe' : (arg_0: TokenIndex) => Promise<Result>,
 }
 export type Error = { 'other' : string } |
   { 'alreadyRegistered' : string } |
   { 'unauthorized' : string } |
   { 'notYetRegistered' : string };
 export type Nft = { 'MyExtStandardNft' : TokenIdentifier };
-export type NftStatus = { 'Bid' : Nft__1 } |
+export type NftStatus = {
+    'BidOffered' : {
+      'nft' : Nft__1,
+      'from' : CanisterIDText,
+      'exhibitNftIndex' : TokenIndex__1,
+    }
+  } |
   { 'Stay' : Nft__1 } |
-  { 'Exhibit' : Nft__1 };
+  { 'Exhibit' : Nft__1 } |
+  {
+    'BidOffering' : {
+      'to' : CanisterIDText,
+      'nft' : Nft__1,
+      'exhibitNftIndex' : TokenIndex__1,
+    }
+  } |
+  { 'Pending' : { 'nft' : Nft__1, 'recipient' : CanisterIDText } };
 export type Nft__1 = { 'MyExtStandardNft' : TokenIdentifier };
-export type Result = { 'ok' : bigint } |
+export type Result = { 'ok' : Nft } |
   { 'err' : Error };
 export type Result_1 = { 'ok' : null } |
   { 'err' : Error };
+export type Result_2 = { 'ok' : TokenIndex } |
+  { 'err' : Error };
+export type Result_3 = { 'ok' : UserId } |
+  { 'err' : Error };
 export type TokenIdentifier = string;
+export type TokenIndex = bigint;
+export type TokenIndex__1 = bigint;
 export type UserId = Principal;
 export interface _SERVICE extends ChildCanister {}

--- a/src/declarations/ChildCanister/ChildCanister.did.d.ts
+++ b/src/declarations/ChildCanister/ChildCanister.did.d.ts
@@ -5,13 +5,15 @@ export interface CanisterIdList { 'myExtStandardNft' : CanisterIDText }
 export interface ChildCanister {
   'acceptBidOffer' : (
       arg_0: { 'bidToken' : TokenIndex, 'exhibitToken' : TokenIndex },
-    ) => Promise<Result_1>,
+    ) => Promise<Result_2>,
   'exhibitMyNft' : (arg_0: TokenIndex) => Promise<Result_1>,
-  'getAssetOwnerByTokenIndex' : (arg_0: TokenIndex) => Promise<Result_3>,
+  'getAssetByTokenIndex' : (arg_0: TokenIndex) => Promise<Result_5>,
+  'getAssetOwnerByTokenIndex' : (arg_0: TokenIndex) => Promise<Result_4>,
   'getAssetOwners' : () => Promise<Array<[TokenIndex, UserId]>>,
   'getAssets' : () => Promise<Array<[TokenIndex, NftStatus]>>,
+  'getAuctionByTokenIndex' : (arg_0: TokenIndex) => Promise<Result_3>,
   'getAuctions' : () => Promise<
-      Array<[TokenIndex, Array<[UserId, TokenIndex]>]>
+      Array<[TokenIndex, Array<[TokenIndex, UserId]>]>
     >,
   'importMyNft' : (arg_0: Nft) => Promise<Result_2>,
   'offerBidMyNft' : (
@@ -20,6 +22,9 @@ export interface ChildCanister {
         'bidToken' : TokenIndex,
         'exhibitToken' : TokenIndex,
       },
+    ) => Promise<Result_2>,
+  'selectTokenInAuction' : (
+      arg_0: { 'selectedToken' : TokenIndex, 'exhibitToken' : TokenIndex },
     ) => Promise<Result_1>,
   'sendToMe' : (arg_0: TokenIndex) => Promise<Result>,
 }
@@ -37,6 +42,9 @@ export type NftStatus = {
   } |
   { 'Stay' : Nft__1 } |
   { 'Exhibit' : Nft__1 } |
+  { 'Selected' : Nft__1 } |
+  { 'NotSelected' : Nft__1 } |
+  { 'ExhibitEnd' : Nft__1 } |
   {
     'BidOffering' : {
       'to' : CanisterIDText,
@@ -52,7 +60,11 @@ export type Result_1 = { 'ok' : null } |
   { 'err' : Error };
 export type Result_2 = { 'ok' : TokenIndex } |
   { 'err' : Error };
-export type Result_3 = { 'ok' : UserId } |
+export type Result_3 = { 'ok' : Array<[TokenIndex, UserId]> } |
+  { 'err' : Error };
+export type Result_4 = { 'ok' : UserId } |
+  { 'err' : Error };
+export type Result_5 = { 'ok' : NftStatus } |
   { 'err' : Error };
 export type TokenIdentifier = string;
 export type TokenIndex = bigint;

--- a/src/declarations/ChildCanister/ChildCanister.did.js
+++ b/src/declarations/ChildCanister/ChildCanister.did.js
@@ -1,5 +1,7 @@
 export const idlFactory = ({ IDL }) => {
-  const CanisterIdList = IDL.Record({ 'myExtStandardNft' : IDL.Text });
+  const CanisterIDText = IDL.Text;
+  const CanisterIdList = IDL.Record({ 'myExtStandardNft' : CanisterIDText });
+  const TokenIndex = IDL.Nat;
   const Error = IDL.Variant({
     'other' : IDL.Text,
     'alreadyRegistered' : IDL.Text,
@@ -8,37 +10,74 @@ export const idlFactory = ({ IDL }) => {
   });
   const Result_1 = IDL.Variant({ 'ok' : IDL.Null, 'err' : Error });
   const UserId = IDL.Principal;
+  const Result_3 = IDL.Variant({ 'ok' : UserId, 'err' : Error });
   const TokenIdentifier = IDL.Text;
   const Nft__1 = IDL.Variant({ 'MyExtStandardNft' : TokenIdentifier });
+  const TokenIndex__1 = IDL.Nat;
   const NftStatus = IDL.Variant({
-    'Bid' : Nft__1,
+    'BidOffered' : IDL.Record({
+      'nft' : Nft__1,
+      'from' : CanisterIDText,
+      'exhibitNftIndex' : TokenIndex__1,
+    }),
     'Stay' : Nft__1,
     'Exhibit' : Nft__1,
+    'BidOffering' : IDL.Record({
+      'to' : CanisterIDText,
+      'nft' : Nft__1,
+      'exhibitNftIndex' : TokenIndex__1,
+    }),
+    'Pending' : IDL.Record({ 'nft' : Nft__1, 'recipient' : CanisterIDText }),
   });
   const Nft = IDL.Variant({ 'MyExtStandardNft' : TokenIdentifier });
-  const Result = IDL.Variant({ 'ok' : IDL.Nat, 'err' : Error });
+  const Result_2 = IDL.Variant({ 'ok' : TokenIndex, 'err' : Error });
+  const CanisterIDText__1 = IDL.Text;
+  const Result = IDL.Variant({ 'ok' : Nft, 'err' : Error });
   const ChildCanister = IDL.Service({
-    'exhibitMyNft' : IDL.Func([IDL.Nat], [Result_1], []),
+    'acceptBidOffer' : IDL.Func(
+        [IDL.Record({ 'bidToken' : TokenIndex, 'exhibitToken' : TokenIndex })],
+        [Result_1],
+        [],
+      ),
+    'exhibitMyNft' : IDL.Func([TokenIndex], [Result_1], []),
+    'getAssetOwnerByTokenIndex' : IDL.Func([TokenIndex], [Result_3], ['query']),
     'getAssetOwners' : IDL.Func(
         [],
-        [IDL.Vec(IDL.Tuple(IDL.Nat, UserId))],
+        [IDL.Vec(IDL.Tuple(TokenIndex, UserId))],
         ['query'],
       ),
     'getAssets' : IDL.Func(
         [],
-        [IDL.Vec(IDL.Tuple(IDL.Nat, NftStatus))],
+        [IDL.Vec(IDL.Tuple(TokenIndex, NftStatus))],
         ['query'],
       ),
     'getAuctions' : IDL.Func(
         [],
-        [IDL.Vec(IDL.Tuple(IDL.Nat, IDL.Vec(IDL.Tuple(UserId, IDL.Nat))))],
+        [
+          IDL.Vec(
+            IDL.Tuple(TokenIndex, IDL.Vec(IDL.Tuple(UserId, TokenIndex)))
+          ),
+        ],
         ['query'],
       ),
-    'importMyNft' : IDL.Func([Nft], [Result], []),
+    'importMyNft' : IDL.Func([Nft], [Result_2], []),
+    'offerBidMyNft' : IDL.Func(
+        [
+          IDL.Record({
+            'exhibitCanisterId' : CanisterIDText__1,
+            'bidToken' : TokenIndex,
+            'exhibitToken' : TokenIndex,
+          }),
+        ],
+        [Result_1],
+        [],
+      ),
+    'sendToMe' : IDL.Func([TokenIndex], [Result], []),
   });
   return ChildCanister;
 };
 export const init = ({ IDL }) => {
-  const CanisterIdList = IDL.Record({ 'myExtStandardNft' : IDL.Text });
+  const CanisterIDText = IDL.Text;
+  const CanisterIdList = IDL.Record({ 'myExtStandardNft' : CanisterIDText });
   return [IDL.Principal, CanisterIdList];
 };

--- a/src/declarations/ChildCanister/ChildCanister.did.js
+++ b/src/declarations/ChildCanister/ChildCanister.did.js
@@ -8,9 +8,8 @@ export const idlFactory = ({ IDL }) => {
     'unauthorized' : IDL.Text,
     'notYetRegistered' : IDL.Text,
   });
+  const Result_2 = IDL.Variant({ 'ok' : TokenIndex, 'err' : Error });
   const Result_1 = IDL.Variant({ 'ok' : IDL.Null, 'err' : Error });
-  const UserId = IDL.Principal;
-  const Result_3 = IDL.Variant({ 'ok' : UserId, 'err' : Error });
   const TokenIdentifier = IDL.Text;
   const Nft__1 = IDL.Variant({ 'MyExtStandardNft' : TokenIdentifier });
   const TokenIndex__1 = IDL.Nat;
@@ -22,6 +21,9 @@ export const idlFactory = ({ IDL }) => {
     }),
     'Stay' : Nft__1,
     'Exhibit' : Nft__1,
+    'Selected' : Nft__1,
+    'NotSelected' : Nft__1,
+    'ExhibitEnd' : Nft__1,
     'BidOffering' : IDL.Record({
       'to' : CanisterIDText,
       'nft' : Nft__1,
@@ -29,18 +31,25 @@ export const idlFactory = ({ IDL }) => {
     }),
     'Pending' : IDL.Record({ 'nft' : Nft__1, 'recipient' : CanisterIDText }),
   });
+  const Result_5 = IDL.Variant({ 'ok' : NftStatus, 'err' : Error });
+  const UserId = IDL.Principal;
+  const Result_4 = IDL.Variant({ 'ok' : UserId, 'err' : Error });
+  const Result_3 = IDL.Variant({
+    'ok' : IDL.Vec(IDL.Tuple(TokenIndex, UserId)),
+    'err' : Error,
+  });
   const Nft = IDL.Variant({ 'MyExtStandardNft' : TokenIdentifier });
-  const Result_2 = IDL.Variant({ 'ok' : TokenIndex, 'err' : Error });
   const CanisterIDText__1 = IDL.Text;
   const Result = IDL.Variant({ 'ok' : Nft, 'err' : Error });
   const ChildCanister = IDL.Service({
     'acceptBidOffer' : IDL.Func(
         [IDL.Record({ 'bidToken' : TokenIndex, 'exhibitToken' : TokenIndex })],
-        [Result_1],
+        [Result_2],
         [],
       ),
     'exhibitMyNft' : IDL.Func([TokenIndex], [Result_1], []),
-    'getAssetOwnerByTokenIndex' : IDL.Func([TokenIndex], [Result_3], ['query']),
+    'getAssetByTokenIndex' : IDL.Func([TokenIndex], [Result_5], ['query']),
+    'getAssetOwnerByTokenIndex' : IDL.Func([TokenIndex], [Result_4], ['query']),
     'getAssetOwners' : IDL.Func(
         [],
         [IDL.Vec(IDL.Tuple(TokenIndex, UserId))],
@@ -51,11 +60,12 @@ export const idlFactory = ({ IDL }) => {
         [IDL.Vec(IDL.Tuple(TokenIndex, NftStatus))],
         ['query'],
       ),
+    'getAuctionByTokenIndex' : IDL.Func([TokenIndex], [Result_3], ['query']),
     'getAuctions' : IDL.Func(
         [],
         [
           IDL.Vec(
-            IDL.Tuple(TokenIndex, IDL.Vec(IDL.Tuple(UserId, TokenIndex)))
+            IDL.Tuple(TokenIndex, IDL.Vec(IDL.Tuple(TokenIndex, UserId)))
           ),
         ],
         ['query'],
@@ -66,6 +76,16 @@ export const idlFactory = ({ IDL }) => {
           IDL.Record({
             'exhibitCanisterId' : CanisterIDText__1,
             'bidToken' : TokenIndex,
+            'exhibitToken' : TokenIndex,
+          }),
+        ],
+        [Result_2],
+        [],
+      ),
+    'selectTokenInAuction' : IDL.Func(
+        [
+          IDL.Record({
+            'selectedToken' : TokenIndex,
             'exhibitToken' : TokenIndex,
           }),
         ],

--- a/src/declarations/NFTBarter/NFTBarter.did
+++ b/src/declarations/NFTBarter/NFTBarter.did
@@ -24,6 +24,7 @@ type NFTBarter =
    getMyChildCanisters: () -> (Result_2) query;
    getMyProfile: () -> (Result_1) query;
    getTargetNftCanisterId: () -> (CanisterID) query;
+   isFamily: (CanisterIDText) -> (bool);
    isRegistered: () -> (bool) query;
    mintChildCanister: () -> (Result);
    register: () -> (Result_1);
@@ -36,5 +37,6 @@ type Error =
    other: text;
    unauthorized: text;
  };
+type CanisterIDText = text;
 type CanisterID = principal;
 service : () -> NFTBarter

--- a/src/declarations/NFTBarter/NFTBarter.did.d.ts
+++ b/src/declarations/NFTBarter/NFTBarter.did.d.ts
@@ -1,5 +1,6 @@
 import type { Principal } from '@dfinity/principal';
 export type CanisterID = Principal;
+export type CanisterIDText = string;
 export type Error = { 'other' : string } |
   { 'alreadyRegistered' : string } |
   { 'unauthorized' : string } |
@@ -9,6 +10,7 @@ export interface NFTBarter {
   'getMyChildCanisters' : () => Promise<Result_2>,
   'getMyProfile' : () => Promise<Result_1>,
   'getTargetNftCanisterId' : () => Promise<CanisterID>,
+  'isFamily' : (arg_0: CanisterIDText) => Promise<boolean>,
   'isRegistered' : () => Promise<boolean>,
   'mintChildCanister' : () => Promise<Result>,
   'register' : () => Promise<Result_1>,

--- a/src/declarations/NFTBarter/NFTBarter.did.js
+++ b/src/declarations/NFTBarter/NFTBarter.did.js
@@ -10,6 +10,7 @@ export const idlFactory = ({ IDL }) => {
   const Result_2 = IDL.Variant({ 'ok' : IDL.Vec(CanisterID), 'err' : Error });
   const UserProfile = IDL.Variant({ 'none' : IDL.Null });
   const Result_1 = IDL.Variant({ 'ok' : UserProfile, 'err' : Error });
+  const CanisterIDText = IDL.Text;
   const Result = IDL.Variant({ 'ok' : CanisterID, 'err' : Error });
   const NFTBarter = IDL.Service({
     'getAllChildCanisters' : IDL.Func(
@@ -20,6 +21,7 @@ export const idlFactory = ({ IDL }) => {
     'getMyChildCanisters' : IDL.Func([], [Result_2], ['query']),
     'getMyProfile' : IDL.Func([], [Result_1], ['query']),
     'getTargetNftCanisterId' : IDL.Func([], [CanisterID], ['query']),
+    'isFamily' : IDL.Func([CanisterIDText], [IDL.Bool], []),
     'isRegistered' : IDL.Func([], [IDL.Bool], ['query']),
     'mintChildCanister' : IDL.Func([], [Result], []),
     'register' : IDL.Func([], [Result_1], []),

--- a/src/tests/e2e/exhibit.test.ts
+++ b/src/tests/e2e/exhibit.test.ts
@@ -25,6 +25,8 @@ declare module '../../declarations/ChildCanister/ChildCanister.did.js' {
 }
 import {
   Nft,
+  UserId,
+  TokenIndex,
   _SERVICE as IChildCanister,
   idlFactory as childIdlFactory,
 } from '../../declarations/ChildCanister/ChildCanister.did.js';
@@ -82,7 +84,7 @@ const actorOfBob = createNFTBarterActor(identityOptionOfBob);
 const generativeNFTActorOfBob = createGenerativeNFTActor(identityOptionOfBob);
 
 // beforeAll has long-running calls
-jest.setTimeout(60000);
+jest.setTimeout(120000);
 
 describe('Exhibit an NFT test', () => {
   let tokenId: TokenIdentifier;
@@ -178,8 +180,6 @@ describe('Exhibit an NFT test', () => {
 });
 
 describe('Bid an NFT test', () => {
-  type TokenIndex = bigint; // TokenIndex in candid file is number, which is wrong.
-
   let bidTokenId: TokenIdentifier;
 
   let bidTokenIndex: TokenIndex = BigInt(1); // Assume Bob imports only one NFT
@@ -287,18 +287,18 @@ describe('Bid an NFT test', () => {
       bidToken: bidTokenIndex,
       exhibitToken: exhibitTokenIndex,
     });
-    expect(res).toStrictEqual({
-      ok: null,
-    });
+
+    // Due to an error in serializing a bigint, test number instead of object.
+    const index = 'ok' in res ? Number(res.ok) : 0;
+    expect(index).toBeGreaterThan(0);
   });
 
   it("Now auction includes a bid by Bob (technically, a bid by Bob's child canister)", async () => {
     const res = await childCanisterActorOfAliceCalledByBob.getAuctions();
     const [tokenIndex, bids] = res[0];
-    const [bidder, tokenIndexOfBid] = bids[0];
-    expect(tokenIndex).toBe(exhibitTokenIndex);
+    const [_, bidder] = bids[0];
+    expect(Number(tokenIndex)).toBe(Number(exhibitTokenIndex));
     expect(bids.length).toBe(1);
-    expect(tokenIndexOfBid).toBe(bidTokenIndex);
     expect(bidder.toText()).toBe(childCanisterIdOfBob.toText());
   });
 
@@ -326,6 +326,217 @@ describe('Bid an NFT test', () => {
     const res = await generativeNFTActorOfBob.bearer(bidTokenId);
     expect(res).toStrictEqual({
       ok: childCanisterAccountIdOfAlice,
+    });
+  });
+});
+
+describe('Select NFT test', () => {
+  type TokenIndex = bigint; // TokenIndex in candid file is number, which is wrong.
+
+  let numberOfBids = 4;
+  let bidTokenIds: TokenIdentifier[];
+  let bidNfts: Nft[];
+  let bidTokenIndexInChildCanisterOfBob: TokenIndex[];
+
+  let exhibitTokenIndex: TokenIndex;
+  let bidTokenIndexInChildCanisterOfAlice: number[];
+
+  let childCanisterIdOfAlice: CanisterID;
+  let childCanisterIdOfBob: CanisterID;
+
+  let childCanisterAccountIdOfAlice: string;
+  let childCanisterAccountIdOfBob: string;
+
+  let childCanisterActorOfAlice: ActorSubclass<IChildCanister>;
+  let childCanisterActorOfAliceCalledByBob: ActorSubclass<IChildCanister>;
+  let childCanisterActorOfBob: ActorSubclass<IChildCanister>;
+
+  let auction: [TokenIndex, UserId][];
+
+  let selectedTokenIndex: TokenIndex;
+
+  beforeAll(async () => {
+    // Mint an NFT
+    const mintRequest: MintRequest = {
+      to: userBob,
+      metadata: [],
+    };
+
+    bidTokenIds = await Promise.all(
+      new Array(numberOfBids).fill(0).map(async (_) => {
+        const tokenIndexExt = await generativeNFTActorOfBob.mintNFT(
+          mintRequest
+        );
+        return generateTokenIdentifier(generativeNFTCanisterId, tokenIndexExt);
+      })
+    );
+
+    bidNfts = bidTokenIds.map((tokenId) => {
+      return { MyExtStandardNft: tokenId };
+    });
+
+    // Mint a child canister
+    await actorOfBob.register();
+    const res = await actorOfBob.mintChildCanister();
+    if ('ok' in res) {
+      childCanisterIdOfBob = res.ok;
+    }
+
+    childCanisterActorOfBob =
+      createChildCanisterActorByCanisterId(childCanisterIdOfBob)(
+        identityOptionOfBob
+      );
+
+    // Transfer the NFT to the child canister
+    const childCanister: User = {
+      principal: childCanisterIdOfBob,
+    };
+    await Promise.all(
+      bidTokenIds.map(async (bidTokenId) => {
+        const transferRequest: TransferRequest = {
+          from: userBob,
+          to: childCanister,
+          token: bidTokenId,
+          notify: false,
+          memo: [],
+          subaccount: [],
+          amount: BigInt(1),
+        };
+        await generativeNFTActorOfBob.transfer(transferRequest);
+      })
+    );
+    // Import NFT
+    bidTokenIndexInChildCanisterOfBob = await Promise.all(
+      bidNfts.map(async (bidNft) => {
+        const res = await childCanisterActorOfBob.importMyNft(bidNft);
+        return 'ok' in res ? res.ok : BigInt(0);
+      })
+    );
+
+    // Get Alice's child canister ids
+    const childCanisters = await actorOfBob.getAllChildCanisters();
+    childCanisterIdOfAlice = childCanisters.filter(([_, userId]) => {
+      return userId.toText() === userAlice.principal.toText();
+    })[0][0];
+    childCanisterActorOfAliceCalledByBob = createChildCanisterActorByCanisterId(
+      childCanisterIdOfAlice
+    )(identityOptionOfBob);
+
+    // Get accound id of child canisters
+    childCanisterAccountIdOfAlice = principalToAccountIdentifier(
+      childCanisterIdOfAlice.toText(),
+      0
+    );
+    childCanisterAccountIdOfBob = principalToAccountIdentifier(
+      childCanisterIdOfBob.toText(),
+      0
+    );
+
+    childCanisterActorOfAlice = createChildCanisterActorByCanisterId(
+      childCanisterIdOfAlice
+    )(identityOptionOfAlice);
+
+    // Get auction
+    const auctions = await childCanisterActorOfAliceCalledByBob.getAuctions();
+    exhibitTokenIndex = auctions[0][0];
+  });
+
+  it('Bob can offer multiple bids', async () => {
+    bidTokenIndexInChildCanisterOfAlice = await Promise.all(
+      bidTokenIndexInChildCanisterOfBob.map(async (bidTokenIndex) => {
+        const res = await childCanisterActorOfBob.offerBidMyNft({
+          exhibitCanisterId: childCanisterIdOfAlice.toText(),
+          bidToken: bidTokenIndex,
+          exhibitToken: exhibitTokenIndex,
+        });
+        return 'ok' in res ? Number(res.ok) : 0;
+      })
+    );
+    expect(bidTokenIndexInChildCanisterOfAlice).not.toContain(0);
+  });
+
+  it('Multiple bids can be found', async () => {
+    const res =
+      await childCanisterActorOfAliceCalledByBob.getAuctionByTokenIndex(
+        exhibitTokenIndex
+      );
+    auction = 'ok' in res ? res.ok : [];
+    expect(auction.length).toBeGreaterThanOrEqual(numberOfBids);
+  });
+
+  it('Alice can select a NFT', async () => {
+    selectedTokenIndex = BigInt(bidTokenIndexInChildCanisterOfAlice[0]);
+    const res = await childCanisterActorOfAlice.selectTokenInAuction({
+      selectedToken: selectedTokenIndex,
+      exhibitToken: exhibitTokenIndex,
+    });
+    expect(res).toStrictEqual({
+      ok: null,
+    });
+  });
+
+  it("Now the owner of selected token is Alice's child canister", async () => {
+    const res =
+      await childCanisterActorOfAliceCalledByBob.getAssetOwnerByTokenIndex(
+        selectedTokenIndex
+      );
+    expect(res).toStrictEqual({
+      ok: childCanisterIdOfAlice,
+    });
+  });
+
+  it("Now the owner of exhibited token is Bob's child canister", async () => {
+    const res =
+      await childCanisterActorOfAliceCalledByBob.getAssetOwnerByTokenIndex(
+        exhibitTokenIndex
+      );
+    expect(res).toStrictEqual({
+      ok: childCanisterIdOfBob,
+    });
+  });
+
+  it('Check if the new status of selected nft is #Selected', async () => {
+    const res = await childCanisterActorOfAliceCalledByBob.getAssetByTokenIndex(
+      selectedTokenIndex
+    );
+    expect(res).toStrictEqual({
+      ok: {
+        Selected: expect.anything(),
+      },
+    });
+  });
+
+  it('Check if the new status of exhibit nft is #ExhibitEnd', async () => {
+    const res = await childCanisterActorOfAliceCalledByBob.getAssetByTokenIndex(
+      exhibitTokenIndex
+    );
+    expect(res).toStrictEqual({
+      ok: {
+        ExhibitEnd: {
+          MyExtStandardNft: expect.anything(),
+        },
+      },
+    });
+  });
+
+  it('Check if the status of non-selected nfts are #NotSelected', async () => {
+    const nonSelectedTokenIndices = bidTokenIndexInChildCanisterOfAlice.filter(
+      (t) => {
+        return t !== Number(selectedTokenIndex);
+      }
+    );
+    nonSelectedTokenIndices.forEach(async (t) => {
+      const res =
+        await childCanisterActorOfAliceCalledByBob.getAssetByTokenIndex(
+          BigInt(t)
+        );
+      expect(res).toStrictEqual({
+        ok: {
+          NotSelected: {
+            MyExtStandardNft: expect.anything(),
+          },
+        },
+      });
     });
   });
 });

--- a/src/tests/e2e/exhibit.test.ts
+++ b/src/tests/e2e/exhibit.test.ts
@@ -2,7 +2,7 @@ import { Secp256k1KeyIdentity } from '@dfinity/identity';
 import { ActorSubclass } from '@dfinity/agent';
 import fetch from 'isomorphic-fetch';
 import { IDL } from '@dfinity/candid';
-import { jest } from '@jest/globals'
+import { jest } from '@jest/globals';
 
 declare module '../../declarations/NFTBarter/NFTBarter.did.js' {
   function idlFactory(): IDL.ServiceClass;
@@ -34,6 +34,7 @@ import {
   generateTokenIdentifier,
   principalToAccountIdentifier,
 } from '../../NFTBarter_assets/src/utils/ext';
+import { getTokenIdAndNftStatusFromAsset } from '../../NFTBarter_assets/src/utils/nft';
 import localCanisterIds from '../../../.dfx/local/canister_ids.json';
 
 const canisterId = localCanisterIds.NFTBarter.local;
@@ -43,8 +44,9 @@ const canisterId = localCanisterIds.NFTBarter.local;
 const createNFTBarterActor =
   curriedCreateActor<INFTBarter>(idlFactory)(canisterId);
 
-const createGenerativeNFTActor =
-  curriedCreateActor<IGenerativeArtNFT>(nftIdlFactory)(generativeNFTCanisterId);
+const createGenerativeNFTActor = curriedCreateActor<IGenerativeArtNFT>(
+  nftIdlFactory
+)(generativeNFTCanisterId);
 
 const createChildCanisterActorByCanisterId =
   curriedCreateActor<IChildCanister>(childIdlFactory);
@@ -61,10 +63,26 @@ const userAlice: User = {
 };
 
 const actorOfAlice = createNFTBarterActor(identityOptionOfAlice);
-const generativeNFTActorOfAlice = createGenerativeNFTActor(identityOptionOfAlice);
+const generativeNFTActorOfAlice = createGenerativeNFTActor(
+  identityOptionOfAlice
+);
+
+const identityOptionOfBob = {
+  agentOptions: {
+    identity: Secp256k1KeyIdentity.generate(),
+    fetch,
+    host: 'http://localhost:8000',
+  },
+};
+const userBob: User = {
+  principal: identityOptionOfBob.agentOptions.identity.getPrincipal(),
+};
+
+const actorOfBob = createNFTBarterActor(identityOptionOfBob);
+const generativeNFTActorOfBob = createGenerativeNFTActor(identityOptionOfBob);
 
 // beforeAll has long-running calls
-jest.setTimeout(12000);
+jest.setTimeout(60000);
 
 describe('Exhibit an NFT test', () => {
   let tokenId: TokenIdentifier;
@@ -89,8 +107,13 @@ describe('Exhibit an NFT test', () => {
     if ('ok' in res) {
       childCanisterId = res.ok;
     }
-    childCanisterAccountId = principalToAccountIdentifier(childCanisterId.toText(), 0);
-    childCanisterActorOfAlice = createChildCanisterActorByCanisterId(childCanisterId)(identityOptionOfAlice);
+    childCanisterAccountId = principalToAccountIdentifier(
+      childCanisterId.toText(),
+      0
+    );
+    childCanisterActorOfAlice = createChildCanisterActorByCanisterId(
+      childCanisterId
+    )(identityOptionOfAlice);
 
     // Transfer the NFT to the child canister
     const childCanister: User = {
@@ -135,7 +158,9 @@ describe('Exhibit an NFT test', () => {
 
   it('Alice can exhibit the NFT to the child canister', async () => {
     const tokenIndexOnChildCanister = BigInt(1);
-    const res = await childCanisterActorOfAlice.exhibitMyNft(tokenIndexOnChildCanister);
+    const res = await childCanisterActorOfAlice.exhibitMyNft(
+      tokenIndexOnChildCanister
+    );
     expect(res).toStrictEqual({
       ok: null,
     });
@@ -148,6 +173,159 @@ describe('Exhibit an NFT test', () => {
     expect(res[0][0]).toBe(tokenIndexOnChildCanister);
     expect(res[0][1]).toStrictEqual({
       Exhibit: nft,
+    });
+  });
+});
+
+describe('Bid an NFT test', () => {
+  type TokenIndex = bigint; // TokenIndex in candid file is number, which is wrong.
+
+  let bidTokenId: TokenIdentifier;
+
+  let bidTokenIndex: TokenIndex = BigInt(1); // Assume Bob imports only one NFT
+  let exhibitTokenIndex: TokenIndex;
+  let bidTokenIndexInChildCanisterOfAlice: TokenIndex;
+
+  let bidNft: Nft;
+
+  let childCanisterIdOfAlice: CanisterID;
+  let childCanisterIdOfBob: CanisterID;
+
+  let childCanisterAccountIdOfAlice: string;
+  let childCanisterAccountIdOfBob: string;
+
+  let childCanisterActorOfAliceCalledByBob: ActorSubclass<IChildCanister>;
+  let childCanisterActorOfBob: ActorSubclass<IChildCanister>;
+
+  beforeAll(async () => {
+    // Mint an NFT
+    const mintRequest: MintRequest = {
+      to: userBob,
+      metadata: [],
+    };
+    const tokenIndex = await generativeNFTActorOfBob.mintNFT(mintRequest);
+    bidTokenId = generateTokenIdentifier(generativeNFTCanisterId, tokenIndex);
+    bidNft = { MyExtStandardNft: bidTokenId };
+
+    // Mint a child canister
+    await actorOfBob.register();
+    const res = await actorOfBob.mintChildCanister();
+    if ('ok' in res) {
+      childCanisterIdOfBob = res.ok;
+    }
+
+    childCanisterActorOfBob =
+      createChildCanisterActorByCanisterId(childCanisterIdOfBob)(
+        identityOptionOfBob
+      );
+
+    // Transfer the NFT to the child canister
+    const childCanister: User = {
+      principal: childCanisterIdOfBob,
+    };
+    const transferRequest: TransferRequest = {
+      from: userBob,
+      to: childCanister,
+      token: bidTokenId,
+      notify: false,
+      memo: [],
+      subaccount: [],
+      amount: BigInt(1),
+    };
+    await generativeNFTActorOfBob.transfer(transferRequest);
+
+    // Get Alice's child canister ids
+    const childCanisters = await actorOfBob.getAllChildCanisters();
+    childCanisterIdOfAlice = childCanisters.filter(([_, userId]) => {
+      return userId.toText() === userAlice.principal.toText();
+    })[0][0];
+    childCanisterActorOfAliceCalledByBob = createChildCanisterActorByCanisterId(
+      childCanisterIdOfAlice
+    )(identityOptionOfBob);
+
+    // Get accound id of child canisters
+    childCanisterAccountIdOfAlice = principalToAccountIdentifier(
+      childCanisterIdOfAlice.toText(),
+      0
+    );
+    childCanisterAccountIdOfBob = principalToAccountIdentifier(
+      childCanisterIdOfBob.toText(),
+      0
+    );
+  });
+
+  it('Bob can see auctions opened by Alice', async () => {
+    const res = await childCanisterActorOfAliceCalledByBob.getAuctions();
+
+    // Note that this test does not care how many auctions are open
+    // but at least one auction must be currently open.
+    expect(res.length).toBeGreaterThanOrEqual(1);
+
+    const [tokenIndex, bids] = res[0];
+    exhibitTokenIndex = tokenIndex;
+
+    expect(bids.length).toBe(0);
+  });
+
+  it("Bob's child canister can import an NFT", async () => {
+    const res = await childCanisterActorOfBob.importMyNft(bidNft);
+    expect(res).toStrictEqual({
+      ok: bidTokenIndex,
+    });
+  });
+
+  it('Make sure the child canister is the bearer of the NFT', async () => {
+    const res = await generativeNFTActorOfBob.bearer(bidTokenId);
+    expect(res).toStrictEqual({
+      ok: childCanisterAccountIdOfBob,
+    });
+  });
+
+  it('Bob can offer a bid', async () => {
+    const res = await childCanisterActorOfBob.offerBidMyNft({
+      exhibitCanisterId: childCanisterIdOfAlice.toText(),
+      bidToken: bidTokenIndex,
+      exhibitToken: exhibitTokenIndex,
+    });
+    expect(res).toStrictEqual({
+      ok: null,
+    });
+  });
+
+  it("Now auction includes a bid by Bob (technically, a bid by Bob's child canister)", async () => {
+    const res = await childCanisterActorOfAliceCalledByBob.getAuctions();
+    const [tokenIndex, bids] = res[0];
+    const [bidder, tokenIndexOfBid] = bids[0];
+    expect(tokenIndex).toBe(exhibitTokenIndex);
+    expect(bids.length).toBe(1);
+    expect(tokenIndexOfBid).toBe(bidTokenIndex);
+    expect(bidder.toText()).toBe(childCanisterIdOfBob.toText());
+  });
+
+  it("Assets in Alice's child canister include a bid by Bob", async () => {
+    const assets = await childCanisterActorOfAliceCalledByBob.getAssets();
+    const nfts = assets
+      .map((asset) => getTokenIdAndNftStatusFromAsset(asset))
+      .filter((nft) => nft.tokenId === bidTokenId);
+    expect(nfts.length).toBe(1);
+
+    bidTokenIndexInChildCanisterOfAlice = nfts[0].tokenIndexOnChildCanister;
+  });
+
+  it("On Alice's child canister, asset owner of the bidded token is Bob's child canister", async () => {
+    const res =
+      await childCanisterActorOfAliceCalledByBob.getAssetOwnerByTokenIndex(
+        bidTokenIndexInChildCanisterOfAlice
+      );
+    expect(res).toStrictEqual({
+      ok: childCanisterIdOfBob,
+    });
+  });
+
+  it("On the NFT canister, actual asset owner of the bidded token is Alice's child canister", async () => {
+    const res = await generativeNFTActorOfBob.bearer(bidTokenId);
+    expect(res).toStrictEqual({
+      ok: childCanisterAccountIdOfAlice,
     });
   });
 });

--- a/src/tests/e2e/mintChildCanister.test.ts
+++ b/src/tests/e2e/mintChildCanister.test.ts
@@ -1,6 +1,7 @@
 import { Secp256k1KeyIdentity } from '@dfinity/identity';
 import fetch from 'isomorphic-fetch';
 import { IDL } from '@dfinity/candid';
+import { jest } from '@jest/globals';
 
 declare module '../../declarations/NFTBarter/NFTBarter.did.js' {
   function idlFactory(): IDL.ServiceClass;
@@ -37,6 +38,9 @@ const identityOptionOfAnonymous = {
   },
 };
 const actorOfAnonymous = createNFTBarterActor(identityOptionOfAnonymous);
+
+// beforeAll has long-running calls
+jest.setTimeout(10000);
 
 describe('Mint child canister test', () => {
   let childCanisterId: CanisterID;


### PR DESCRIPTION
# 概要・目的
オークションに入札、落札機能を追加
<!-- [必須] Pull Request の概要・目的を記載する -->

<!-- 該当のissueがあれば記載する-->
Fixes #75 

# 変更内容
## やったこと
- 変数名の変更とtypoの修正 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/66b1583209a3b3d915f95aa5c1d07a786ecc0bd2
- プリミティブ型の目的を明確するため型名を追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/0a7df49a9a00aaf9f9e79b927853b9b1aeaa4bbe
- main canister に `isFamily` メソッドを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/412ab625fe65156a63367a113a5bec904670b4f2
- `#Exhibit` へのステータス変更の場所を変更 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/f4d3ca8e37e0b453a89e4f483a27c415f802fd4e
- チェック箇所の追加とヘルパー関数の拡充 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/7040bb80e8c2b55ab7b4d645462351cac923ce65
- 入札機能の追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/b75d737e8969d4dadcd2ddbc52e8cd75b1e6e45e
- 入札機能のe2eテストを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/81865615f123c4aef621a5ed56bb0537f9d5c947
- 落札機能の追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/5c483d2ba17cbbfbeb044d502ec3ba9d97fcf171
- 落札機能のe2eテストを追加 https://github.com/Japan-DfinityInfoHub/nft-barter/commit/5c483d2ba17cbbfbeb044d502ec3ba9d97fcf171
<!-- [必須] この Pull Request で行った変更を記載する -->

## やらないこと
- Child Canister からユーザーウォレットへのNFTの引き出し機能の追加
- 入札・落札に関するフロントエンドの実装
<!-- [非必須] この Pull Request ではスコープ外とした事項を記載する (必要に応じてissue化すること) -->

## 影響範囲
- Child Canister 
- e2e テスト
<!-- [非必須] コード変更の影響範囲があれば記載する-->

# 動作確認
- `npm run test` をローカル実行し all tests passed
- 本PRで確認
<!-- [必須] 行った動作確認とその結果を記載する -->

# 補足
主要な変更点ご確認ください
## _auctions のkey value
key と value を以下のように入れ替えました。
```diff
- let _auctions = HashMap.HashMap<Nat, HashMap.HashMap<UserId, TokenIndex>>
+ let _auctions = HashMap.HashMap<TokenIndex, HashMap.HashMap<TokenIndex, UserId>>
```
理由としては、
- 物々交換なので、ユーザーの入札を1つに限定する必要は必ずしもない（複数の異なるNFTを入札しても問題ない）
- UserIdをキーとする場合、すでに当該ユーザーの入札がある場合の処理を入れる必要がある

の2点です。問題あればご指摘ください。

## NftStatus の Pending に`recipient`を追加
```
    #Pending : {
      recipient : CanisterIDText;
      nft : Nft;
    };
```
sendToMeメソッド呼び出しの際、NFTの受け取りをチェックするために変数を追加しました。
sendToMeでの認証周辺をご確認ください。

## changeNftStatus メソッド
 
changeNftStatus メソッドでは `oldNftStatus` と `newStatus` に分け、`oldNftStatus` の種類によって変化可能な `newStatus` が制限されるようにしました。
愚直にやるとswitchのネストが深くなったので、`let a = switch () {};` パターンの活用で深さを抑えた方が良いと考えました。
なお、ステータスの変更はメソッドの最後に行うように変更しました。

## 自分自身へのNFTのtransfer は hasNft 関数に切り分け

NFTの所有の確認が目的なので、処理の目的が明確になるように`hasNft`関数に分離しました。

## ChildCanisterIF の削除

ChildCanister の自分自身の型をそのまま使う方が良いと判断しました。
```diff
- switch (await (actor(famliyId) : Types.ChildCanisterIF).acceptOffer()) {
+ switch (await (actor(exhibitCanisterId) : ChildCanister).acceptBidOffer({
```

<!-- [非必須] 特にレビューして欲しい観点や参考URL等、補足情報を記載する -->
